### PR TITLE
Feat: 모달, 토스트 컴포넌트 구현

### DIFF
--- a/src/pages/error/error-page.tsx
+++ b/src/pages/error/error-page.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import NotFound from '@images/404.svg';
+import Button from '@components/button/button';
 
 export default function ErrorPage() {
   const nav = useNavigate();
@@ -13,13 +14,9 @@ export default function ErrorPage() {
         <p className='title3 text-center text-gray-900'>존재하지 않는 페이지입니다.</p>
       </div>
 
-      <button
-        type='button'
-        onClick={() => nav('/')}
-        className='text-gray-white bg-primary-700 active:bg-primary-800 button3 w-full cursor-pointer rounded-[12px] py-[1.2rem]'
-      >
+      <Button fullWidth={true} onClick={() => nav('/')}>
         메인으로 돌아가기
-      </button>
+      </Button>
     </div>
   );
 }

--- a/src/pages/home/components/banner/home-banner.tsx
+++ b/src/pages/home/components/banner/home-banner.tsx
@@ -28,7 +28,7 @@ export default function HomeBanner({ hasLoan, title, dday, className = '', bgCla
       )}
       aria-label='홈 배너'
     >
-      <img src={PolygonImg} alt='' className='absolute top-0 -left-[0.8rem] w-[10.6rem] select-none' loading='lazy' />
+      <img src={PolygonImg} alt='' className='absolute top-0 left-[-0.8rem] w-[10.6rem] select-none' loading='lazy' />
 
       {hasLoan ? (
         <div className='flex-col gap-[0.8rem]'>
@@ -54,7 +54,7 @@ export default function HomeBanner({ hasLoan, title, dday, className = '', bgCla
         <img
           src={ICON_BOOKS}
           alt=''
-          className='absolute top-[1.2rem] left-[1.2rem] h-[2.5rem] w-[2.5rem] -rotate-[22deg]'
+          className='absolute top-[1.2rem] left-[1.2rem] h-[2.5rem] w-[2.5rem] rotate-[-22deg]'
           loading='lazy'
         />
         <img

--- a/src/pages/library/library-page.tsx
+++ b/src/pages/library/library-page.tsx
@@ -3,6 +3,7 @@ import LibraryTab, { type LibraryTabKey } from '@pages/library/components/librar
 import { useQueryTab } from '@hooks/use-query-tab';
 import SelectDropdown from '@components/dropdown/select-dropdown';
 import { toast } from '@libs/toast';
+import { modal } from '@libs/modal';
 import Button from '@components/button/button';
 
 import {
@@ -14,23 +15,69 @@ import {
   type RentStatus,
 } from '@components/dropdown/constants/select-options';
 
+import { TOAST_MESSAGE } from '@constants/toast-messages';
+import { MODAL_TITLE } from '@constants/modal-presets';
+
 export default function LibraryPage() {
   const [tab, setTab] = useQueryTab<LibraryTabKey>('tab', 'books', ['books', 'libraries']);
+
+  const onLogoutConfirm = async () => {
+    const res = await modal.confirm({
+      title: MODAL_TITLE.LOGOUT,
+      confirmVariant: 'danger',
+    });
+    if (res.ok) toast.success('로그아웃되었습니다.');
+  };
+
+  const onCartReplace = async () => {
+    const res = await modal.confirm({
+      title: MODAL_TITLE.CART_REPLACE,
+      confirmVariant: 'danger',
+    });
+    if (res.ok) toast.info('기존 도서를 비우고 담았어요.');
+  };
+
+  const onPasswordPrompt = async () => {
+    const res = await modal.prompt({
+      title: MODAL_TITLE.PASSWORD_PROMPT,
+      placeholder: '비밀번호',
+      password: true,
+      confirmVariant: 'primary',
+      maxLength: 32,
+    });
+    if (res.ok) toast.success('인증되었습니다.');
+    else toast.error('인증이 취소되었습니다.');
+  };
 
   return (
     <>
       <LibraryTab value={tab} onChange={setTab} />
       {tab === 'libraries' ? <LibraryList /> : <BookList />}
-      <div className='flex-col gap-[1rem]'>
-        <Button type='button' onClick={() => toast.info('이메일을 확인해 주세요.')}>
-          Info
-        </Button>
-        <Button type='button' onClick={() => toast.success('로그인에 성공했습니다.')}>
-          Success
-        </Button>
-        <Button type='button' onClick={() => toast.error('로그인에 실패했습니다.')}>
-          Error
-        </Button>
+
+      <div className='mt-[2rem] flex flex-col gap-[1rem]'>
+        <div className='flex items-center gap-[0.8rem]'>
+          <Button type='button' variant='outline' onClick={() => toast.info(TOAST_MESSAGE.EMAIL_CHECK)}>
+            Toast Info
+          </Button>
+          <Button type='button' variant='primary' onClick={() => toast.success(TOAST_MESSAGE.LOGIN_SUCCESS)}>
+            Toast Success
+          </Button>
+          <Button type='button' variant='danger' onClick={() => toast.error(TOAST_MESSAGE.LOGIN_FAIL)}>
+            Toast Error
+          </Button>
+        </div>
+
+        <div className='flex items-center gap-[0.8rem]'>
+          <Button type='button' variant='danger' onClick={onLogoutConfirm}>
+            모달: 로그아웃 확인
+          </Button>
+          <Button type='button' variant='danger' onClick={onCartReplace}>
+            모달: 장바구니 교체
+          </Button>
+          <Button type='button' variant='primary' onClick={onPasswordPrompt}>
+            모달: 비밀번호 입력
+          </Button>
+        </div>
       </div>
     </>
   );

--- a/src/pages/library/library-page.tsx
+++ b/src/pages/library/library-page.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react';
 import LibraryTab, { type LibraryTabKey } from '@pages/library/components/library-tab';
 import { useQueryTab } from '@hooks/use-query-tab';
 import SelectDropdown from '@components/dropdown/select-dropdown';
+import { toast } from '@libs/toast';
+import Button from '@components/button/button';
 
 import {
   LIB_SORT_OPTIONS,
@@ -19,6 +21,17 @@ export default function LibraryPage() {
     <>
       <LibraryTab value={tab} onChange={setTab} />
       {tab === 'libraries' ? <LibraryList /> : <BookList />}
+      <div className='flex-col gap-[1rem]'>
+        <Button type='button' onClick={() => toast.info('이메일을 확인해 주세요.')}>
+          Info
+        </Button>
+        <Button type='button' onClick={() => toast.success('로그인에 성공했습니다.')}>
+          Success
+        </Button>
+        <Button type='button' onClick={() => toast.error('로그인에 실패했습니다.')}>
+          Error
+        </Button>
+      </div>
     </>
   );
 }

--- a/src/shared/components/button/button.tsx
+++ b/src/shared/components/button/button.tsx
@@ -19,7 +19,7 @@ export default function Button({
   fullWidth = false,
   roundStyle = 'rounded-[12px]',
   loading = false,
-  className = 'px-[1.2rem]',
+  className = 'p-[1.2rem]',
   children,
   onClick,
   disabled,

--- a/src/shared/components/button/button.tsx
+++ b/src/shared/components/button/button.tsx
@@ -43,6 +43,7 @@ export default function Button({
       disabled={disabled}
       onClick={handleClick}
       className={cn(
+        'cursor-pointer',
         BUTTON_TOKENS.base,
         variants[variant],
         fullWidth ? 'w-full' : 'w-auto',

--- a/src/shared/components/tab/underline-tab.tsx
+++ b/src/shared/components/tab/underline-tab.tsx
@@ -35,7 +35,7 @@ export default function UnderlineTab({
       role='tablist'
       aria-label='탐색 탭'
       className={cn(
-        'bg-gray-white shadow-top-fixed sticky top-0 z-[var(--z-tabs,40)]',
+        'bg-gray-white shadow-top-fixed sticky top-0 z-[var(--z-header)]',
         HEIGHT_CLASS,
         'relative w-full overflow-hidden px-[2rem]',
         className

--- a/src/shared/constants/modal-presets.ts
+++ b/src/shared/constants/modal-presets.ts
@@ -1,0 +1,7 @@
+export type ModalTitleKey = 'LOGOUT' | 'CART_REPLACE' | 'PASSWORD_PROMPT';
+
+export const MODAL_TITLE: Readonly<Record<ModalTitleKey, string>> = {
+  LOGOUT: '로그아웃 하시겠습니까?',
+  CART_REPLACE: '장바구니에는 같은 도서관의 도서만\n담을 수 있습니다. 기존 도서를 삭제하고\n새로 담을까요?',
+  PASSWORD_PROMPT: '인증이 필요합니다.\n비밀번호를 입력해 주세요.',
+};

--- a/src/shared/constants/toast-messages.ts
+++ b/src/shared/constants/toast-messages.ts
@@ -1,0 +1,7 @@
+export type ToastMessageKey = 'EMAIL_CHECK' | 'LOGIN_SUCCESS' | 'LOGIN_FAIL';
+
+export const TOAST_MESSAGE: Readonly<Record<ToastMessageKey, string>> = {
+  EMAIL_CHECK: '이메일을 확인해 주세요.',
+  LOGIN_SUCCESS: '로그인에 성공했습니다.',
+  LOGIN_FAIL: '로그인에 실패했습니다.',
+};

--- a/src/shared/layouts/layout.tsx
+++ b/src/shared/layouts/layout.tsx
@@ -65,7 +65,6 @@ export default function Layout() {
         return null;
       })();
 
-  // 바텀시트 겹침/노출 제어 (전체 폭 기준)
   const { visible: floatVisible, bottomStyle } = useFloatingButtonGuard();
 
   return (
@@ -92,12 +91,11 @@ export default function Layout() {
       {floatingBtn && (
         <div
           className={cn(
-            'pointer-events-none fixed inset-x-0 z-[110] transition-opacity duration-200',
+            'pointer-events-none fixed inset-x-0 z-[var(--z-bottom-nav)] transition-opacity duration-200',
             floatVisible ? 'opacity-100' : 'opacity-0'
           )}
           style={bottomStyle}
         >
-          {/* 컨테이너 폭을 바텀내브와 동일하게 중앙 정렬 */}
           <div className='relative left-1/2 w-full max-w-[43rem] -translate-x-1/2'>
             <div className='pointer-events-auto absolute right-[1.6rem]'>
               {floatingBtn.name === 'back' ? (

--- a/src/shared/libs/modal.tsx
+++ b/src/shared/libs/modal.tsx
@@ -1,0 +1,260 @@
+import { useEffect, useId, useSyncExternalStore, useState } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { cn } from '@libs/cn';
+import Button from '@components/button/button';
+import Input from '@components/input/input';
+
+type ModalVariant = 'primary' | 'danger';
+type Result<T> = { ok: boolean; value?: T };
+
+type BaseConfig = {
+  title: string;
+  description?: string;
+  confirmText?: string;
+  cancelText?: string;
+  confirmVariant?: ModalVariant;
+  dismissOnOverlay?: boolean;
+};
+
+type ConfirmConfig = BaseConfig;
+
+type PromptConfig = BaseConfig & {
+  placeholder?: string;
+  // 비밀번호 입력 여부
+  password?: boolean;
+  maxLength?: number;
+};
+
+type ModalKind =
+  | { type: 'confirm'; cfg: ConfirmConfig; resolve: (r: Result<undefined>) => void }
+  | { type: 'prompt'; cfg: PromptConfig; resolve: (r: Result<string>) => void };
+
+type ModalItem = { id: string; kind: ModalKind };
+
+const store = (() => {
+  let stack: ModalItem[] = [];
+  const listeners = new Set<() => void>();
+  const emit = () => listeners.forEach((fn) => fn());
+  const subscribe = (fn: () => void) => {
+    listeners.add(fn);
+    return () => listeners.delete(fn);
+  };
+  const getSnapshot = () => stack;
+  const push = (m: ModalItem) => {
+    stack = [...stack, m];
+    emit();
+  };
+  const pop = (id: string) => {
+    stack = stack.filter((x) => x.id !== id);
+    emit();
+  };
+  return { subscribe, getSnapshot, push, pop };
+})();
+
+type RootHost = HTMLElement & { __BOOKLINK_MODAL_ROOT__?: Root };
+
+function ensureHost() {
+  const el: RootHost =
+    (document.getElementById('modal-portal') as RootHost) ??
+    (() => {
+      const n = document.createElement('div') as RootHost;
+      n.id = 'modal-portal';
+      document.body.appendChild(n);
+      return n;
+    })();
+  if (!el.__BOOKLINK_MODAL_ROOT__) {
+    el.__BOOKLINK_MODAL_ROOT__ = createRoot(el);
+  }
+  el.__BOOKLINK_MODAL_ROOT__!.render(<ModalViewport />);
+}
+
+function makeId(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) return crypto.randomUUID();
+  const r = Math.floor(Math.random() * 1_000_000).toString(36);
+  return `m_${Date.now()}_${r}`;
+}
+
+export const modal = {
+  confirm(cfg: ConfirmConfig): Promise<Result<undefined>> {
+    ensureHost();
+    return new Promise((resolve) => {
+      store.push({ id: makeId(), kind: { type: 'confirm', cfg, resolve } });
+    });
+  },
+  prompt(cfg: PromptConfig): Promise<Result<string>> {
+    ensureHost();
+    return new Promise((resolve) => {
+      store.push({ id: makeId(), kind: { type: 'prompt', cfg, resolve } });
+    });
+  },
+};
+
+function useModals(): ModalItem[] {
+  return useSyncExternalStore(store.subscribe, store.getSnapshot, store.getSnapshot);
+}
+
+function ModalViewport() {
+  const stack = useModals();
+  const current = stack[stack.length - 1];
+
+  useEffect(() => {
+    const prev = document.body.style.overflow;
+    if (current) document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [current]);
+
+  if (!current) return null;
+
+  const { id, kind } = current;
+  const cfg = kind.cfg;
+
+  const close = () => store.pop(id);
+
+  const onEsc: React.KeyboardEventHandler<HTMLDivElement> = (e) => {
+    if (e.key === 'Escape') {
+      if (kind.type === 'confirm') kind.resolve({ ok: false });
+      else kind.resolve({ ok: false, value: '' });
+      close();
+    }
+  };
+
+  const confirmVariant = cfg.confirmVariant ?? (kind.type === 'confirm' ? 'danger' : 'primary');
+  const confirmColor: 'danger' | 'primary' = confirmVariant === 'danger' ? 'danger' : 'primary';
+
+  const onOverlayClick = () => {
+    if (cfg.dismissOnOverlay) {
+      if (kind.type === 'confirm') kind.resolve({ ok: false });
+      else kind.resolve({ ok: false, value: '' });
+      close();
+    }
+  };
+
+  return (
+    <div
+      role='dialog'
+      aria-modal='true'
+      onKeyDown={onEsc}
+      className={cn('fixed inset-0 z-[var(--z-modal)]', 'flex-row-center')}
+    >
+      <div className='bg-opacity-light absolute inset-0' onClick={onOverlayClick} />
+      <div className={cn('relative mx-[4rem] w-[min(43rem,calc(100vw-8rem))]', 'bg-gray-white rounded-[16px]')}>
+        {kind.type === 'confirm' ? (
+          <ConfirmContent cfg={cfg} onClose={close} onResolve={(r) => kind.resolve(r)} confirmColor={confirmColor} />
+        ) : (
+          <PromptContent cfg={cfg} onClose={close} onResolve={(r) => kind.resolve(r)} confirmColor={confirmColor} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ConfirmContent({
+  cfg,
+  onClose,
+  onResolve,
+  confirmColor,
+}: {
+  cfg: ConfirmConfig;
+  onClose: () => void;
+  onResolve: (r: { ok: boolean }) => void;
+  confirmColor: 'primary' | 'danger';
+}) {
+  const titleId = useId();
+
+  const onConfirm = () => {
+    onResolve({ ok: true });
+    onClose();
+  };
+  const onCancel = () => {
+    onResolve({ ok: false });
+    onClose();
+  };
+
+  return (
+    <div aria-labelledby={titleId} className='p-[2rem]'>
+      <div className='flex flex-col items-center gap-[1.2rem] text-center'>
+        <h2 id={titleId} className='title6 whitespace-pre-line text-gray-900'>
+          {cfg.title}
+        </h2>
+        {cfg.description && <p className='body4 whitespace-pre-line text-gray-900'>{cfg.description}</p>}
+      </div>
+      <div className='mt-[2rem] flex items-center gap-[0.8rem]'>
+        <Button variant='outline' fullWidth roundStyle='rounded-[12px]' typoStyle='button3' onClick={onCancel}>
+          {cfg.cancelText ?? '취소'}
+        </Button>
+        <Button
+          variant={confirmColor === 'danger' ? 'danger' : 'primary'}
+          fullWidth
+          roundStyle='rounded-[12px]'
+          typoStyle='button3'
+          onClick={onConfirm}
+        >
+          {cfg.confirmText ?? '확인'}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function PromptContent({
+  cfg,
+  onClose,
+  onResolve,
+  confirmColor,
+}: {
+  cfg: PromptConfig;
+  onClose: () => void;
+  onResolve: (r: { ok: boolean; value: string }) => void;
+  confirmColor: 'primary' | 'danger';
+}) {
+  const titleId = useId();
+  const [val, setVal] = useState('');
+
+  const onConfirm = () => {
+    onResolve({ ok: true, value: val });
+    onClose();
+  };
+  const onCancel = () => {
+    onResolve({ ok: false, value: '' });
+    onClose();
+  };
+
+  return (
+    <div aria-labelledby={titleId} className='p-[2rem]'>
+      <div className='flex flex-col items-center gap-[1.2rem] text-center'>
+        <h2 id={titleId} className='title6 whitespace-pre-line text-gray-900'>
+          {cfg.title}
+        </h2>
+        {cfg.description && <p className='body4 whitespace-pre-line text-gray-900'>{cfg.description}</p>}
+      </div>
+
+      <div className='mt-[1.6rem]'>
+        <Input
+          id='modal-prompt-input'
+          type={cfg.password ? 'password' : 'text'}
+          placeholder={cfg.placeholder ?? ''}
+          maxLength={cfg.maxLength ?? 50}
+          value={val}
+          onChange={(e) => setVal(e.currentTarget.value)}
+        />
+      </div>
+
+      <div className='mt-[2rem] flex items-center gap-[0.8rem]'>
+        <Button variant='outline' fullWidth roundStyle='rounded-[12px]' typoStyle='button3' onClick={onCancel}>
+          {cfg.cancelText ?? '취소'}
+        </Button>
+        <Button
+          variant={confirmColor === 'danger' ? 'danger' : 'primary'}
+          fullWidth
+          roundStyle='rounded-[12px]'
+          typoStyle='button3'
+          onClick={onConfirm}
+        >
+          {cfg.confirmText ?? '확인'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/shared/libs/toast.tsx
+++ b/src/shared/libs/toast.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useSyncExternalStore, useId } from 'react';
-import { createRoot } from 'react-dom/client';
+import { createRoot, type Root } from 'react-dom/client';
 import { cn } from '@libs/cn';
 import Icon from '@components/icon';
 
@@ -46,20 +46,22 @@ const store = (() => {
   return { add, remove, subscribe, getSnapshot };
 })();
 
-let mounted = false;
+type RootHost = HTMLElement & { __BOOKLINK_TOAST_ROOT__?: Root };
 
 function ensureHost() {
-  if (mounted) return;
-  const rootEl =
-    document.getElementById('toast-portal') ??
+  const el: RootHost =
+    (document.getElementById('toast-portal') as RootHost) ??
     (() => {
-      const el = document.createElement('div');
-      el.id = 'toast-portal';
-      document.body.appendChild(el);
-      return el;
+      const n = document.createElement('div') as RootHost;
+      n.id = 'toast-portal';
+      document.body.appendChild(n);
+      return n;
     })();
-  createRoot(rootEl).render(<ToastViewport />);
-  mounted = true;
+
+  if (!el.__BOOKLINK_TOAST_ROOT__) {
+    el.__BOOKLINK_TOAST_ROOT__ = createRoot(el);
+  }
+  el.__BOOKLINK_TOAST_ROOT__!.render(<ToastViewport />);
 }
 
 function makeId(): string {

--- a/src/shared/libs/toast.tsx
+++ b/src/shared/libs/toast.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useSyncExternalStore, useId } from 'react';
+import { createRoot } from 'react-dom/client';
+import { cn } from '@libs/cn';
+import Icon from '@components/icon';
+
+type ToastKind = 'info' | 'success' | 'error';
+
+type ToastItem = {
+  id: string;
+  kind: ToastKind;
+  message: string;
+  durationMs: number;
+};
+
+const store = (() => {
+  let list: ToastItem[] = [];
+  const listeners = new Set<() => void>();
+  const timers: Record<string, number> = {};
+
+  const emit = () => listeners.forEach((fn) => fn());
+
+  const add = (item: ToastItem) => {
+    list = [...list, item];
+    emit();
+    const tid = window.setTimeout(() => remove(item.id), item.durationMs);
+    timers[item.id] = tid;
+  };
+
+  const remove = (id: string) => {
+    list = list.filter((t) => t.id !== id);
+    const tid = timers[id];
+    if (typeof tid === 'number') {
+      window.clearTimeout(tid);
+      delete timers[id];
+    }
+    emit();
+  };
+
+  const subscribe = (fn: () => void) => {
+    listeners.add(fn);
+    return () => listeners.delete(fn);
+  };
+
+  const getSnapshot = () => list;
+
+  return { add, remove, subscribe, getSnapshot };
+})();
+
+let mounted = false;
+
+function ensureHost() {
+  if (mounted) return;
+  const rootEl =
+    document.getElementById('toast-portal') ??
+    (() => {
+      const el = document.createElement('div');
+      el.id = 'toast-portal';
+      document.body.appendChild(el);
+      return el;
+    })();
+  createRoot(rootEl).render(<ToastViewport />);
+  mounted = true;
+}
+
+function makeId(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) return crypto.randomUUID();
+  const rnd = Math.floor(Math.random() * 1_000_000).toString(36);
+  return `t_${Date.now()}_${rnd}`;
+}
+
+const DEFAULT_MS = 3000;
+
+function show(kind: ToastKind, message: string, durationMs?: number) {
+  ensureHost();
+  const id = makeId();
+  store.add({ id, kind, message, durationMs: durationMs ?? DEFAULT_MS });
+  return id;
+}
+
+export const toast = {
+  info: (msg: string, ms?: number) => show('info', msg, ms),
+  success: (msg: string, ms?: number) => show('success', msg, ms),
+  error: (msg: string, ms?: number) => show('error', msg, ms),
+};
+
+function useToasts(): ToastItem[] {
+  return useSyncExternalStore(store.subscribe, store.getSnapshot, store.getSnapshot);
+}
+
+function ToastViewport() {
+  const toasts = useToasts();
+  const liveId = useId();
+  useEffect(() => {}, []);
+  return (
+    <div
+      id={liveId}
+      aria-live='polite'
+      aria-atomic='false'
+      className={cn(
+        'pointer-events-none fixed inset-x-0 bottom-[2rem] z-[var(--z-modal)]',
+        'flex-col-center gap-[1.2rem]'
+      )}
+    >
+      {toasts.map((t) => (
+        <ToastCard key={t.id} toast={t} />
+      ))}
+    </div>
+  );
+}
+
+function ToastCard({ toast: t }: { toast: ToastItem }) {
+  const palette =
+    t.kind === 'info'
+      ? { icon: 'toast-info', text: 'text-gray-white' }
+      : t.kind === 'success'
+        ? { icon: 'toast-success', text: 'text-gray-white' }
+        : { icon: 'toast-error', text: 'text-gray-white' };
+
+  return (
+    <div className='pointer-events-auto w-[min(90vw,40rem)]' role='status' aria-atomic='true'>
+      <div
+        className={cn(
+          'flex items-center gap-[1rem]',
+          'px-[2rem] py-[1.4rem]',
+          'bg-opacity-dark',
+          'rounded-[6px]',
+          'backdrop-blur-[0.2rem]',
+          'shadow-md',
+          palette.text
+        )}
+      >
+        <Icon name={palette.icon} size={2.0} ariaHidden />
+        <p className='body5 flex-1'>{t.message}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/shared/styles/theme.css
+++ b/src/shared/styles/theme.css
@@ -58,6 +58,7 @@
   --z-overlay: 6;
   --z-bottom-nav: 7;
   --z-bottom-sheet: 8;
+  --z-modal: 9;
 
   /* Radius / Shadow */
   --radius-md: 12px;

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -37,6 +37,7 @@
       "@layouts/*": ["./src/shared/layouts/*"],
       "@images/*": ["./src/shared/assets/images/*"],
       "@icons/*": ["./src/shared/assets/icons/*"],
+      "@types/*": ["./src/shared/types/*"],
       "@/*": ["./src/*"]
     }
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
       '@routes': path.resolve(__dirname, 'src/shared/routes'),
       '@images': path.resolve(__dirname, 'src/shared/assets/images'),
       '@icons': path.resolve(__dirname, 'src/shared/assets/icons'),
+      '@types': path.resolve(__dirname, 'src/shared/types'),
       '@': path.resolve(__dirname, 'src'),
     },
   },


### PR DESCRIPTION
## 📝작업 내용

모달 컴포넌트와 토스트 컴포넌트를 구현했습니다.
공통 상수 폴더 내에 모달, 토스트 관련 파일이 있습니다. 해당 파일에 텍스트 작성하고 사용해 주시면 됩니다!

추가 세팅 따로 없이 토스트, 모달을 임포트해서 사용하면 됩니다.
```tsx
import { toast } from '@libs/toast';
import { modal } from '@libs/modal';

### 토스트
```tsx
<Button type="button" variant="outline" onClick={() => toast.info(TOAST_MESSAGE.EMAIL_CHECK)}>
  Toast Info
</Button>
<Button type="button" variant="primary" onClick={() => toast.success(TOAST_MESSAGE.LOGIN_SUCCESS)}>
  Toast Success
</Button>
<Button type="button" variant="danger" onClick={() => toast.error(TOAST_MESSAGE.LOGIN_FAIL)}>
  Toast Error
</Button>
```

### 모달(비밀번호 입력도 지원)
```tsx
// 로그아웃 확인
const res = await modal.confirm({
  title: MODAL_TITLE.LOGOUT,
  confirmVariant: 'danger',
});
if (res.ok) toast.success('로그아웃되었습니다.');

// 장바구니 교체
const res2 = await modal.confirm({
  title: MODAL_TITLE.CART_REPLACE, // 개행은 \n 사용
  confirmVariant: 'danger',
});
if (res2.ok) toast.info('기존 도서를 비우고 담았어요.');

// 비밀번호 입력
const res3 = await modal.prompt({
  title: MODAL_TITLE.PASSWORD_PROMPT,
  placeholder: '비밀번호',
  password: true,
  confirmVariant: 'primary',
  maxLength: 32,
});
if (res3.ok) toast.success('인증되었습니다.');
else toast.error('인증이 취소되었습니다.');
```


## 🐢 변경사항

토스트, 모달 컴포넌트 추가

## 📷 스크린샷

<img width="200" alt="image" src="https://github.com/user-attachments/assets/f5f52063-a813-4132-9233-8aae9512e5dc" />

<br />

<img width="200" alt="image" src="https://github.com/user-attachments/assets/ae0b7917-356e-49eb-9449-c0b35bc68c25" />
<br />

<img width="200" alt="image" src="https://github.com/user-attachments/assets/0509992d-9c22-45ec-95f8-96023ec593b0" />
