### PR TITLE
Feat: 도서/도서관 등록 페이지 퍼블리싱

### DIFF
--- a/src/pages/library/book-create-page.tsx
+++ b/src/pages/library/book-create-page.tsx
@@ -1,0 +1,164 @@
+import { useRef, useState } from 'react';
+import Button from '@components/button/button';
+import ButtonFrame from '@components/button/button-frame';
+import Input from '@components/input/input';
+import Icon from '@components/icon';
+
+type Preview = { id: string; url: string };
+
+export default function BookCreatePage() {
+  const fileRef = useRef<HTMLInputElement | null>(null);
+
+  const [images, setImages] = useState<Preview[]>([]);
+  const [title, setTitle] = useState('');
+  const [author, setAuthor] = useState('');
+  const [publisher, setPublisher] = useState('');
+  const [price, setPrice] = useState('');
+  const [category, setCategory] = useState('');
+  const [desc, setDesc] = useState('');
+  const [deposit, setDeposit] = useState('');
+
+  const canSubmit = images.length >= 3 && title.trim().length > 0;
+
+  const onPick = () => fileRef.current?.click();
+
+  const onFiles = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.currentTarget.files ?? []);
+    if (!files.length) return;
+
+    Promise.all(
+      files.map(
+        (f) =>
+          new Promise<Preview>((resolve) => {
+            const reader = new FileReader();
+            reader.onload = () =>
+              resolve({
+                id: `${f.name}-${f.lastModified}-${Math.random().toString(36).slice(2)}`,
+                url: typeof reader.result === 'string' ? reader.result : '',
+              });
+            reader.readAsDataURL(f);
+          })
+      )
+    ).then((previews) => setImages((prev) => [...prev, ...previews]));
+    e.currentTarget.value = '';
+  };
+
+  const submit = () => {
+    if (!canSubmit) return;
+    const payload = {
+      images: images.map((p) => p.url),
+      title: title.trim(),
+      author: author.trim(),
+      publisher: publisher.trim(),
+      price: price.trim(),
+      category: category.trim(),
+      description: desc.trim(),
+      deposit: deposit.trim(),
+    };
+    console.log('create book payload ->', payload);
+  };
+
+  return (
+    <div className='bg-gray-white min-h-dvh text-gray-900'>
+      <div className='mx-auto w-full space-y-[3.5rem] px-[2rem] pt-[2rem] pb-[10rem]'>
+        <div className='flex-col gap-[0.8rem]'>
+          <label className='body5'>책 이미지 (최소 3장으로 앞, 뒤, 내부 사진 업로드)</label>
+
+          <Button variant='primary' fullWidth className='py-[1.2rem]' onClick={onPick} roundStyle='rounded-[12px]'>
+            이미지 업로드
+          </Button>
+          <input ref={fileRef} type='file' accept='image/*' multiple onChange={onFiles} className='hidden' />
+
+          {!!images.length && (
+            <div className='grid grid-cols-2 gap-[0.8rem]'>
+              {images.map((img) => (
+                <div
+                  key={img.id}
+                  className='grid h-[15rem] w-full place-items-center overflow-hidden rounded-[12px] bg-gray-100'
+                >
+                  {img.url ? (
+                    <img src={img.url} alt='' className='h-full w-full object-cover' />
+                  ) : (
+                    <Icon name='book' size={3.2} className='text-gray-400' ariaHidden />
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+
+          <p className='body5 text-primary-700'>처음에 등록한 사진이 목록에 노출됩니다.</p>
+        </div>
+
+        <Input
+          id='book-title'
+          label='책 제목'
+          placeholder='책 제목을 입력해 주세요.'
+          value={title}
+          onChange={(e) => setTitle(e.currentTarget.value)}
+        />
+
+        <Input
+          id='book-author'
+          label='작가'
+          placeholder='작가를 입력해 주세요.'
+          value={author}
+          onChange={(e) => setAuthor(e.currentTarget.value)}
+        />
+
+        <Input
+          id='book-publisher'
+          label='출판사'
+          placeholder='출판사를 입력해 주세요.'
+          value={publisher}
+          onChange={(e) => setPublisher(e.currentTarget.value)}
+        />
+
+        <Input
+          id='book-price'
+          label='정가'
+          placeholder='정가를 입력해 주세요.'
+          inputMode='numeric'
+          value={price}
+          onChange={(e) => setPrice(e.currentTarget.value.replace(/[^\d]/g, ''))}
+        />
+
+        <Input
+          id='book-category'
+          label='카테고리'
+          placeholder='카테고리를 입력해 주세요.'
+          value={category}
+          onChange={(e) => setCategory(e.currentTarget.value)}
+        />
+
+        <Input
+          id='book-desc'
+          label='상세 설명'
+          placeholder='상세 설명을 작성해 주세요.'
+          multiline
+          maxLength={1000}
+          hasLength
+          value={desc}
+          onChange={(e) => setDesc(e.currentTarget.value)}
+          length={desc.length}
+        />
+        <div className='flex-col gap-[0.8rem]'>
+          <Input
+            id='book-deposit'
+            label='보증금'
+            placeholder='숫자만 입력해 주세요.'
+            inputMode='numeric'
+            value={deposit}
+            onChange={(e) => setDeposit(e.currentTarget.value.replace(/[^\d]/g, ''))}
+          />
+          <p className='body5 text-primary-700'>보증금은 정가의 10%가 일반적입니다.</p>
+        </div>
+      </div>
+
+      <ButtonFrame>
+        <Button fullWidth roundStyle='rounded-[12px]' className='py-[1.2rem]' disabled={!canSubmit} onClick={submit}>
+          대여 요청
+        </Button>
+      </ButtonFrame>
+    </div>
+  );
+}

--- a/src/pages/library/library-create-page.tsx
+++ b/src/pages/library/library-create-page.tsx
@@ -2,19 +2,18 @@ import { useRef, useState } from 'react';
 import Button from '@components/button/button';
 import ButtonFrame from '@components/button/button-frame';
 import Input from '@components/input/input';
-import Icon from '@components/icon';
 import TimePicker, { type HMValue } from '@components/time-picker/time-picker';
 
 export default function LibraryCreatePage() {
   const fileRef = useRef<HTMLInputElement | null>(null);
 
-  const [imageUrl, setImageUrl] = useState<string>('');
-  const [name, setName] = useState<string>('');
+  const [imageUrl, setImageUrl] = useState('');
+  const [name, setName] = useState('');
   const [openAt, setOpenAt] = useState<HMValue | undefined>(undefined);
   const [closeAt, setCloseAt] = useState<HMValue | undefined>(undefined);
-  const [intro, setIntro] = useState<string>('');
+  const [intro, setIntro] = useState('');
 
-  const canSubmit = name.trim().length > 0 && !!openAt && !!closeAt;
+  const canSubmit = name.trim().length > 0 && !!openAt && !!closeAt && intro.trim().length > 10;
 
   const onPickImage = () => fileRef.current?.click();
 
@@ -31,7 +30,6 @@ export default function LibraryCreatePage() {
 
   const submit = () => {
     if (!canSubmit) return;
-    // TODO: 실제 API 연동 자리 (지금은 콘솔만)
     const payload: {
       name: string;
       intro: string;
@@ -49,67 +47,46 @@ export default function LibraryCreatePage() {
   };
 
   return (
-    <div className='bg-gray-white h-full min-h-dvh text-gray-900'>
-      <div className='mx-auto w-full max-w-[43rem] px-[2rem] pt-[2rem] pb-[10rem]'>
-        <div className='flex-col gap-[1.2rem]'>
+    <div className='bg-gray-white min-h-dvh text-gray-900'>
+      <div className='mx-auto w-full space-y-[3.5rem] px-[2rem] pt-[2.5rem] pb-[10rem]'>
+        <div className='flex-col gap-[0.8rem]'>
           <label className='body5'>도서관 이미지</label>
-
           <Button variant='primary' fullWidth className='py-[1.2rem]' roundStyle='rounded-[12px]' onClick={onPickImage}>
             이미지 업로드
           </Button>
           <input ref={fileRef} type='file' accept='image/*' onChange={onFile} className='hidden' />
-
-          <div className='mt-[1.2rem] rounded-[20px] bg-gray-100 p-[1.2rem]'>
-            <div className='grid h-[20rem] place-items-center rounded-[20px] bg-gray-100'>
-              {imageUrl ? (
-                <img
-                  src={imageUrl}
-                  alt='도서관 이미지 미리보기'
-                  className='h-full w-full rounded-[20px] object-cover'
-                />
-              ) : (
-                <div className='flex-col-center gap-[0.8rem] text-gray-400'>
-                  <Icon name='book' size={4} ariaHidden />
-                </div>
-              )}
-            </div>
-          </div>
+          {imageUrl && <img src={imageUrl} alt='도서관 이미지 미리보기' className='h-[15rem] w-full object-cover' />}
         </div>
 
-        <div className='mt-[2.4rem]'>
-          <Input
-            id='lib-name'
-            label='도서관 이름'
-            placeholder='도서관 이름을 입력해 주세요.'
-            value={name}
-            onChange={(e) => setName(e.currentTarget.value)}
-          />
-        </div>
+        <Input
+          id='lib-name'
+          label='도서관 이름'
+          placeholder='도서관 이름을 입력해 주세요.'
+          value={name}
+          onChange={(e) => setName(e.currentTarget.value)}
+        />
 
-        <div className='mt-[2.8rem]'>
+        <div>
           <p className='body5 text-gray-900'>영업 시간 (연락 가능한 시간)</p>
-
-          <div className='mt-[1.2rem] flex items-center gap-[1.2rem]'>
+          <div className='flex items-center gap-[1.2rem]'>
             <TimePicker value={openAt} onChange={setOpenAt} placeholder='시간 선택' className='w-[18rem]' />
             <span className='body5 text-gray-400'>—</span>
             <TimePicker value={closeAt} onChange={setCloseAt} placeholder='시간 선택' className='w-[18rem]' />
           </div>
         </div>
 
-        <div className='mt-[2.8rem]'>
-          <Input
-            id='lib-intro'
-            label='소개'
-            placeholder='도서관 소개 글을 작성해 주세요.'
-            multiline
-            maxLength={800}
-            hasLength
-            length={intro.length}
-            value={intro}
-            onChange={(e) => setIntro(e.currentTarget.value)}
-            className='bg-gray-50'
-          />
-        </div>
+        <Input
+          id='lib-intro'
+          label='소개'
+          placeholder='도서관 소개 글을 작성해 주세요.'
+          multiline
+          maxLength={500}
+          hasLength
+          length={intro.length}
+          value={intro}
+          onChange={(e) => setIntro(e.currentTarget.value)}
+          className='bg-gray-50'
+        />
       </div>
 
       <ButtonFrame>

--- a/src/pages/library/library-create-page.tsx
+++ b/src/pages/library/library-create-page.tsx
@@ -1,0 +1,122 @@
+import { useRef, useState } from 'react';
+import Button from '@components/button/button';
+import ButtonFrame from '@components/button/button-frame';
+import Input from '@components/input/input';
+import Icon from '@components/icon';
+import TimePicker, { type HMValue } from '@components/time-picker/time-picker';
+
+export default function LibraryCreatePage() {
+  const fileRef = useRef<HTMLInputElement | null>(null);
+
+  const [imageUrl, setImageUrl] = useState<string>('');
+  const [name, setName] = useState<string>('');
+  const [openAt, setOpenAt] = useState<HMValue | undefined>(undefined);
+  const [closeAt, setCloseAt] = useState<HMValue | undefined>(undefined);
+  const [intro, setIntro] = useState<string>('');
+
+  const canSubmit = name.trim().length > 0 && !!openAt && !!closeAt;
+
+  const onPickImage = () => fileRef.current?.click();
+
+  const onFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.currentTarget.files?.[0];
+    if (!f) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const url = typeof reader.result === 'string' ? reader.result : '';
+      setImageUrl(url);
+    };
+    reader.readAsDataURL(f);
+  };
+
+  const submit = () => {
+    if (!canSubmit) return;
+    // TODO: 실제 API 연동 자리 (지금은 콘솔만)
+    const payload: {
+      name: string;
+      intro: string;
+      openAt: HMValue;
+      closeAt: HMValue;
+      imageUrl?: string;
+    } = {
+      name: name.trim(),
+      intro: intro.trim(),
+      openAt: openAt as HMValue,
+      closeAt: closeAt as HMValue,
+      imageUrl: imageUrl || undefined,
+    };
+    console.log('create library payload ->', payload);
+  };
+
+  return (
+    <div className='bg-gray-white h-full min-h-dvh text-gray-900'>
+      <div className='mx-auto w-full max-w-[43rem] px-[2rem] pt-[2rem] pb-[10rem]'>
+        <div className='flex-col gap-[1.2rem]'>
+          <label className='body5'>도서관 이미지</label>
+
+          <Button variant='primary' fullWidth className='py-[1.2rem]' roundStyle='rounded-[12px]' onClick={onPickImage}>
+            이미지 업로드
+          </Button>
+          <input ref={fileRef} type='file' accept='image/*' onChange={onFile} className='hidden' />
+
+          <div className='mt-[1.2rem] rounded-[20px] bg-gray-100 p-[1.2rem]'>
+            <div className='grid h-[20rem] place-items-center rounded-[20px] bg-gray-100'>
+              {imageUrl ? (
+                <img
+                  src={imageUrl}
+                  alt='도서관 이미지 미리보기'
+                  className='h-full w-full rounded-[20px] object-cover'
+                />
+              ) : (
+                <div className='flex-col-center gap-[0.8rem] text-gray-400'>
+                  <Icon name='book' size={4} ariaHidden />
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className='mt-[2.4rem]'>
+          <Input
+            id='lib-name'
+            label='도서관 이름'
+            placeholder='도서관 이름을 입력해 주세요.'
+            value={name}
+            onChange={(e) => setName(e.currentTarget.value)}
+          />
+        </div>
+
+        <div className='mt-[2.8rem]'>
+          <p className='body5 text-gray-900'>영업 시간 (연락 가능한 시간)</p>
+
+          <div className='mt-[1.2rem] flex items-center gap-[1.2rem]'>
+            <TimePicker value={openAt} onChange={setOpenAt} placeholder='시간 선택' className='w-[18rem]' />
+            <span className='body5 text-gray-400'>—</span>
+            <TimePicker value={closeAt} onChange={setCloseAt} placeholder='시간 선택' className='w-[18rem]' />
+          </div>
+        </div>
+
+        <div className='mt-[2.8rem]'>
+          <Input
+            id='lib-intro'
+            label='소개'
+            placeholder='도서관 소개 글을 작성해 주세요.'
+            multiline
+            maxLength={800}
+            hasLength
+            length={intro.length}
+            value={intro}
+            onChange={(e) => setIntro(e.currentTarget.value)}
+            className='bg-gray-50'
+          />
+        </div>
+      </div>
+
+      <ButtonFrame>
+        <Button fullWidth roundStyle='rounded-[12px]' className='py-[1.2rem]' disabled={!canSubmit} onClick={submit}>
+          등록하기
+        </Button>
+      </ButtonFrame>
+    </div>
+  );
+}

--- a/src/shared/components/time-picker/time-picker.tsx
+++ b/src/shared/components/time-picker/time-picker.tsx
@@ -50,7 +50,6 @@ export default function TimePicker({
 }: Props) {
   const rootRef = useRef<HTMLDivElement | null>(null);
 
-  // 초기값
   const now = new Date();
   const initial: HMValue = value ?? { hour: now.getHours(), minute: now.getMinutes() };
 
@@ -62,18 +61,15 @@ export default function TimePicker({
 
   const hoursList = twelveHour ? HOURS12 : HOURS24;
 
-  // 표시 인덱스
   const valueHourIdx = twelveHour ? (inner.hour % 12 || 12) - 1 : inner.hour;
   const valueMinIdx = inner.minute;
 
-  // 중앙 선택(아이템 사이) 정렬을 위해 값-1을 초기 active로
   const initialHourCenter = (valueHourIdx - 1 + hoursList.length) % hoursList.length;
   const initialMinCenter = (valueMinIdx - 1 + MINUTES.length) % MINUTES.length;
 
   const [activeHourIdx, setActiveHourIdx] = useState<number>(initialHourCenter);
   const [activeMinIdx, setActiveMinIdx] = useState<number>(initialMinCenter);
 
-  // 실제 선택 인덱스 = active + 1
   const selectedHourIdx = (activeHourIdx + 1) % hoursList.length;
   const selectedMinIdx = (activeMinIdx + 1) % MINUTES.length;
 
@@ -175,7 +171,7 @@ export default function TimePicker({
         disabled={disabled}
         onClick={() => setOpen((o) => !o)}
         className={cn(
-          'h-[4.8rem] w-[18rem] px-[0.8rem]',
+          'h-[4.8rem] w-full px-[0.8rem]',
           'bg-gray-50',
           'rounded-[12px]',
           'flex-row-between',
@@ -202,7 +198,6 @@ export default function TimePicker({
               <div className='h-[0px] border-t border-gray-200' />
             </div>
 
-            {/* 시 */}
             <div ref={refHour} className='keen-slider h-[12rem] w-[6rem] overflow-hidden rounded-[10px]'>
               {hoursList.map((h) => (
                 <div key={`h-${h}`} className='keen-slider__slide grid h-[4rem] place-items-center'>

--- a/src/shared/layouts/header-config.ts
+++ b/src/shared/layouts/header-config.ts
@@ -85,6 +85,12 @@ const libraryCreateRule: Rule = (path) =>
     ? { left: 'back', title: '도서관 등록' }
     : undefined;
 
+// 도서 등록
+const bookCreateRule: Rule = (path) =>
+  ROUTES.BOOK_CREATE && matchPath({ path: ROUTES.BOOK_CREATE, end: true }, path)
+    ? { left: 'back', title: '도서 등록' }
+    : undefined;
+
 // 기본
 const fallbackRule = (): HeaderProps => ({
   left: 'back',
@@ -106,6 +112,7 @@ const RULES: ReadonlyArray<Rule> = [
   loginRule,
   signupRule,
   libraryCreateRule,
+  bookCreateRule,
 ];
 
 export function getHeaderForRoute(pathname: string, search: string): HeaderProps {

--- a/src/shared/layouts/header-config.ts
+++ b/src/shared/layouts/header-config.ts
@@ -79,6 +79,12 @@ const chatDetailRule: Rule = (path) => {
     : undefined;
 };
 
+// 도서관 등록
+const libraryCreateRule: Rule = (path) =>
+  ROUTES.LIBRARY_CREATE && matchPath({ path: ROUTES.LIBRARY_CREATE, end: true }, path)
+    ? { left: 'back', title: '도서관 등록' }
+    : undefined;
+
 // 기본
 const fallbackRule = (): HeaderProps => ({
   left: 'back',
@@ -99,6 +105,7 @@ const RULES: ReadonlyArray<Rule> = [
   notiRole,
   loginRule,
   signupRule,
+  libraryCreateRule,
 ];
 
 export function getHeaderForRoute(pathname: string, search: string): HeaderProps {

--- a/src/shared/layouts/layout.tsx
+++ b/src/shared/layouts/layout.tsx
@@ -30,6 +30,7 @@ export default function Layout() {
       isUnder(pathname, ROUTES.SIGNUP) ||
       isUnder(pathname, ROUTES.NOTIFICATION) ||
       isUnder(pathname, ROUTES.LIBRARY_CREATE) ||
+      isUnder(pathname, ROUTES.BOOK_CREATE) ||
       isOnboarding,
     [pathname, isOnboarding]
   );

--- a/src/shared/layouts/layout.tsx
+++ b/src/shared/layouts/layout.tsx
@@ -29,6 +29,7 @@ export default function Layout() {
       isUnder(pathname, ROUTES.LOGIN) ||
       isUnder(pathname, ROUTES.SIGNUP) ||
       isUnder(pathname, ROUTES.NOTIFICATION) ||
+      isUnder(pathname, ROUTES.LIBRARY_CREATE) ||
       isOnboarding,
     [pathname, isOnboarding]
   );
@@ -74,10 +75,7 @@ export default function Layout() {
     >
       {showHeader && headerProps && <Header {...headerProps} />}
 
-      <main
-        id='content'
-        className={cn('scrollbar-hide flex-1 overflow-x-hidden', isAuthOrOnboarding && 'h-dvh overflow-hidden')}
-      >
+      <main id='content' className={cn('scrollbar-hide h-full flex-1 overflow-x-hidden')}>
         <div className='mx-auto w-full'>
           <Outlet />
         </div>

--- a/src/shared/routes/router.tsx
+++ b/src/shared/routes/router.tsx
@@ -10,6 +10,7 @@ import NotificationPage from '@pages/notification/notification-page';
 import LoginPage from '@pages/login/login-page';
 import SignupPage from '@pages/signup/signup-page';
 import OnboardingPage from '@pages/onboarding/onboarding-page';
+import LibraryCreatePage from '@pages/library/library-create-page';
 import { ROUTES } from '@routes/routes-config';
 
 export const router = createBrowserRouter([
@@ -25,6 +26,7 @@ export const router = createBrowserRouter([
       { path: ROUTES.BOARD, element: <BoardPage /> },
       { path: ROUTES.CHAT, element: <ChatPage /> },
       { path: ROUTES.ONBOARDING, element: <OnboardingPage /> },
+      { path: ROUTES.LIBRARY_CREATE, element: <LibraryCreatePage /> },
       { path: ROUTES.NOTIFICATION, element: <NotificationPage /> },
     ],
   },

--- a/src/shared/routes/router.tsx
+++ b/src/shared/routes/router.tsx
@@ -11,6 +11,7 @@ import LoginPage from '@pages/login/login-page';
 import SignupPage from '@pages/signup/signup-page';
 import OnboardingPage from '@pages/onboarding/onboarding-page';
 import LibraryCreatePage from '@pages/library/library-create-page';
+import BookCreatePage from '@pages/library/book-create-page';
 import { ROUTES } from '@routes/routes-config';
 
 export const router = createBrowserRouter([
@@ -27,6 +28,7 @@ export const router = createBrowserRouter([
       { path: ROUTES.CHAT, element: <ChatPage /> },
       { path: ROUTES.ONBOARDING, element: <OnboardingPage /> },
       { path: ROUTES.LIBRARY_CREATE, element: <LibraryCreatePage /> },
+      { path: ROUTES.BOOK_CREATE, element: <BookCreatePage /> },
       { path: ROUTES.NOTIFICATION, element: <NotificationPage /> },
     ],
   },

--- a/src/shared/routes/routes-config.ts
+++ b/src/shared/routes/routes-config.ts
@@ -5,6 +5,7 @@ export const ROUTES = {
   SIGNUP: '/signup',
   LIBRARY: '/library',
   LIBRARY_CREATE: '/library-create',
+  BOOK_CREATE: '/book-create',
   BOARD: '/board',
   ONBOARDING: '/onboarding',
   SETTING: '/mypage',

--- a/src/shared/routes/routes-config.ts
+++ b/src/shared/routes/routes-config.ts
@@ -4,6 +4,7 @@ export const ROUTES = {
   LOGIN: '/login',
   SIGNUP: '/signup',
   LIBRARY: '/library',
+  LIBRARY_CREATE: '/library-create',
   BOARD: '/board',
   ONBOARDING: '/onboarding',
   SETTING: '/mypage',


### PR DESCRIPTION
## 📝작업 내용

도서/도서관 등록 페이지 UI를 구현했습니다.

## 🐢 변경사항

- 도서 등록 페이지 /book-create 추가
- 도서관 등록 페이지 /library-create 추가
- 도서/도서관 등록 헤더


## 🔔 추후 작업

scan 페이지를 만들고
스캔 성공 시 스캔된 내용을 인풋에 채운 상태로 도서 등록 페이지로 이동하고,
스캔 실패 시 도서 등록 페이지로 이동하여 직접 전체 입력할 수 있도록 구현해야 합니다.

## 📷 스크린샷
| 도서 등록                                                                                                               |도서관 등록                                                                                                                 |
| -------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
| <img width="200" alt="도서 등록 – 초기" src="https://github.com/user-attachments/assets/c900eb1d-cd24-4e38-8ea4-f4a7292e2f02" /> | <img width="200" alt="도서 등록 – 입력" src="https://github.com/user-attachments/assets/6ba08f9f-409c-4aec-a4c6-d369a1ae7c47" /> |