### PR TITLE
Feat: 로딩 스피너 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,24 @@
+import { Suspense } from 'react';
 import queryClient from '@libs/query-client';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { RouterProvider } from 'react-router-dom';
 import { router } from '@routes/router';
+import LoadingSpinner from '@components/loading-spinner';
+
+function OverlayFallback() {
+  return (
+    <div className='fixed inset-0 z-[10] grid min-h-dvh place-items-center'>
+      <LoadingSpinner />
+    </div>
+  );
+}
 
 export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
+      <Suspense fallback={<OverlayFallback />}>
+        <RouterProvider router={router} />
+      </Suspense>
     </QueryClientProvider>
   );
 }

--- a/src/shared/components/loading-spinner.tsx
+++ b/src/shared/components/loading-spinner.tsx
@@ -1,0 +1,65 @@
+import Icon from '@components/icon';
+
+type LoadingProps = {
+  title?: string;
+  subtitle?: string;
+  sizeRem?: number;
+  iconSizeRem?: number;
+  className?: string;
+  'aria-label'?: string;
+};
+
+export default function LoadingSpinner({
+  title = '로딩 중입니다.',
+  subtitle = '잠시만 기다려 주세요!',
+  sizeRem = 20,
+  iconSizeRem = 6,
+  className,
+  'aria-label': ariaLabel = '콘텐츠 로딩 중',
+}: LoadingProps) {
+  const strokeWidth = 12;
+  const r = 48 - strokeWidth / 2;
+  const circumference = 2 * Math.PI * r;
+  const arc = circumference * 0.3;
+  const gap = circumference - arc;
+
+  return (
+    <section
+      role='status'
+      aria-live='polite'
+      aria-label={ariaLabel}
+      className={['flex-col-center gap-[2rem] px-[2rem] text-center', className].filter(Boolean).join(' ')}
+    >
+      <div className='relative grid place-items-center' style={{ width: `${sizeRem}rem`, height: `${sizeRem}rem` }}>
+        <svg className='absolute inset-0' viewBox='0 0 100 100' width='100%' height='100%'>
+          <circle cx='50' cy='50' r={r} fill='none' stroke='var(--color-secondary-100)' strokeWidth={strokeWidth} />
+        </svg>
+        <svg
+          className='absolute inset-0 animate-spin'
+          viewBox='0 0 100 100'
+          width='100%'
+          height='100%'
+          style={{ animationDuration: '1.2s' }}
+        >
+          <circle
+            cx='50'
+            cy='50'
+            r={r}
+            fill='none'
+            stroke='var(--color-secondary-900)'
+            strokeWidth={strokeWidth}
+            strokeLinecap='round'
+            strokeDasharray={`${arc} ${gap}`}
+            transform='rotate(-90 50 50)'
+          />
+        </svg>
+        <Icon name='cat' size={iconSizeRem} className='text-gray-600' />
+      </div>
+
+      <div className='flex-col-center gap-[0.8rem]'>
+        <p className='title3 text-gray-900'>{title}</p>
+        <p className='body5 text-gray-500'>{subtitle}</p>
+      </div>
+    </section>
+  );
+}

--- a/src/shared/routes/router.tsx
+++ b/src/shared/routes/router.tsx
@@ -1,19 +1,22 @@
 import { createBrowserRouter } from 'react-router-dom';
-import Layout from '@layouts/layout';
-import ErrorPage from '@pages/error/error-page';
-import HomePage from '@pages/home/home-page';
-import LibraryPage from '@pages/library/library-page';
-import SettingPage from '@pages/setting/setting-page';
-import BoardPage from '@pages/board/board-page';
-import ChatPage from '@pages/chat/chat-page';
-import ChatDetailPage from '@pages/chat/chat-detail-page';
-import NotificationPage from '@pages/notification/notification-page';
-import LoginPage from '@pages/login/login-page';
-import SignupPage from '@pages/signup/signup-page';
-import OnboardingPage from '@pages/onboarding/onboarding-page';
-import LibraryCreatePage from '@pages/library/library-create-page';
-import BookCreatePage from '@pages/library/book-create-page';
+import { lazy } from 'react';
 import { ROUTES } from '@routes/routes-config';
+
+const Layout = lazy(() => import('@layouts/layout'));
+const ErrorPage = lazy(() => import('@pages/error/error-page'));
+
+const HomePage = lazy(() => import('@pages/home/home-page'));
+const LibraryPage = lazy(() => import('@pages/library/library-page'));
+const SettingPage = lazy(() => import('@pages/setting/setting-page'));
+const BoardPage = lazy(() => import('@pages/board/board-page'));
+const ChatPage = lazy(() => import('@pages/chat/chat-page'));
+const ChatDetailPage = lazy(() => import('@pages/chat/chat-detail-page'));
+const NotificationPage = lazy(() => import('@pages/notification/notification-page'));
+const LoginPage = lazy(() => import('@pages/login/login-page'));
+const SignupPage = lazy(() => import('@pages/signup/signup-page'));
+const OnboardingPage = lazy(() => import('@pages/onboarding/onboarding-page'));
+const LibraryCreatePage = lazy(() => import('@pages/library/library-create-page'));
+const BookCreatePage = lazy(() => import('@pages/library/book-create-page'));
 
 export const router = createBrowserRouter([
   {
@@ -21,17 +24,17 @@ export const router = createBrowserRouter([
     errorElement: <ErrorPage />,
     children: [
       { path: ROUTES.HOME, element: <HomePage /> },
-      { path: ROUTES.LOGIN, element: <LoginPage /> },
-      { path: ROUTES.SIGNUP, element: <SignupPage /> },
       { path: ROUTES.LIBRARY, element: <LibraryPage /> },
       { path: ROUTES.SETTING, element: <SettingPage /> },
       { path: ROUTES.BOARD, element: <BoardPage /> },
       { path: ROUTES.CHAT, element: <ChatPage /> },
       { path: ROUTES.CHAT_ROOM(':id'), element: <ChatDetailPage /> },
+      { path: ROUTES.NOTIFICATION, element: <NotificationPage /> },
+      { path: ROUTES.LOGIN, element: <LoginPage /> },
+      { path: ROUTES.SIGNUP, element: <SignupPage /> },
       { path: ROUTES.ONBOARDING, element: <OnboardingPage /> },
       { path: ROUTES.LIBRARY_CREATE, element: <LibraryCreatePage /> },
       { path: ROUTES.BOOK_CREATE, element: <BookCreatePage /> },
-      { path: ROUTES.NOTIFICATION, element: <NotificationPage /> },
     ],
   },
 ]);


### PR DESCRIPTION
## 📝작업 내용

로딩 스피너 컴포넌트를 구현하고 전체 페이지에 lazy 적용하여 코드 스플리트, 로딩 시 App.tsx의 Suspense가 LoadingSpinner 오버레이를 띄우도록 수정하였습니다.
Suspense fallback은 Suspense가 있을 때만 뜨고, 정적 import면 안 뜨므로 lazy가 반드시 필요합니다.

1. 사용자가 경로를 이동 → 해당 라우트 컴포넌트가 아직 로드되지 않았다면 lazy()가 Suspense합니다.
2. Suspense되는 동안 App.tsx의 Suspense fallback이 전면 오버레이 스피너를 렌더합니다.
3. 번들이 받아지면 fallback은 사라지고, 실제 페이지가 표시됩니다.

## 🐢 변경사항

로딩 스피너 구현, 라우팅 lazy 적용, App.tsx에 Suspense 추가

## 📷 스크린샷

<img width="300" alt="image" src="https://github.com/user-attachments/assets/406f421b-075b-419e-abff-0120dfe7e0cf" />
