### PR TITLE
도서관 탐색페이지 도서관 리스트, 도서관 상세 컴포넌트 구현

### DIFF
--- a/src/pages/home/components/card/book-card.tsx
+++ b/src/pages/home/components/card/book-card.tsx
@@ -11,18 +11,18 @@ export default function BookCard({ id, index, imgurl, title, author, expDate, si
   const sizeClasses = {
     small: {
       container:
-        'keen-slider__slide bg-gray-white flex h-[17rem] min-w-[13rem] cursor-pointer flex-col gap-[0.6rem] rounded-[1rem] border border-gray-200',
+        'keen-slider__slide bg-gray-white flex h-[17rem] min-w-[13rem] cursor-pointer flex-col gap-[0.6rem] rounded-[10px] border border-gray-200',
       imageContainer:
-        'flex-row-center relative h-[10rem] overflow-hidden rounded-tl-[1rem] rounded-tr-[1rem] bg-gray-100',
+        'flex-row-center relative h-[10rem] overflow-hidden rounded-tl-[10px] rounded-tr-[10px] bg-gray-100',
       titleClass: 'caption3',
       authorClass: 'caption5',
       iconSize: 3.8,
     },
     large: {
       container:
-        'bg-gray-white flex min-h-[20.9rem] min-w-[15.3rem] cursor-pointer flex-col gap-[0.8rem] rounded-[1rem] border border-gray-200',
+        'bg-gray-white flex min-h-[20.9rem] min-w-[15.3rem] cursor-pointer flex-col gap-[0.8rem] rounded-[10px] border border-gray-200',
       imageContainer:
-        'flex-row-center relative h-[12rem] overflow-hidden rounded-tl-[1rem] rounded-tr-[1rem] bg-gray-100',
+        'flex-row-center relative h-[12rem] overflow-hidden rounded-tl-[10px] rounded-tr-[10px] bg-gray-100',
       titleClass: 'caption1',
       authorClass: 'caption3',
       iconSize: 4.5,
@@ -40,7 +40,7 @@ export default function BookCard({ id, index, imgurl, title, author, expDate, si
           <Icon name='logo-alt' size={currentSize.iconSize} className='text-[#b5b5b5]' />
         )}
         <div
-          className={`flex-row-center caption5 absolute right-[0.45rem] bottom-[0.45rem] h-[1.7rem] w-[3.5rem] rounded-[0.2rem] bg-gray-50 ${expDate <= 3 ? 'text-system-error' : 'text-gray-600'}`}
+          className={`flex-row-center caption5 absolute right-[0.45rem] bottom-[0.45rem] h-[1.7rem] w-[3.5rem] rounded-[2px] bg-gray-50 ${expDate <= 3 ? 'text-system-error' : 'text-gray-600'}`}
         >
           D-{expDate}
         </div>

--- a/src/pages/home/components/card/group-card.tsx
+++ b/src/pages/home/components/card/group-card.tsx
@@ -4,7 +4,7 @@ import type { IGroupCard } from '@pages/home/types/home.types';
 export default function GroupCard({ id, imgurl, groupName, leaderName, memberCount, description }: IGroupCard) {
   console.log(id);
   return (
-    <div className='flex h-[14rem] min-w-[33rem] cursor-pointer flex-col gap-[1.5rem] rounded-[1rem] bg-white px-[2.3rem] py-[2.45rem]'>
+    <div className='flex h-[14rem] min-w-[33rem] cursor-pointer flex-col gap-[1.5rem] rounded-[10px] bg-white px-[2.3rem] py-[2.45rem]'>
       <div className='flex justify-between'>
         <div className='flex-col gap-[0.6rem]'>
           <h1 className='title4 text-gray-900'>{groupName}</h1>
@@ -15,11 +15,11 @@ export default function GroupCard({ id, imgurl, groupName, leaderName, memberCou
             <h3 className='caption5 text-system-error'>{memberCount}명</h3>
           </div>
         </div>
-        <div className='flex-row-center h-[5rem] w-[5rem] rounded-[1rem] bg-gray-100'>
+        <div className='flex-row-center h-[5rem] w-[5rem] rounded-[10px] bg-gray-100'>
           {imgurl ? (
             <img
               src={imgurl}
-              className='h-full w-full rounded-[1rem] object-cover object-center'
+              className='h-full w-full rounded-[10px] object-cover object-center'
               alt='defaultImage'
             ></img>
           ) : (

--- a/src/pages/home/components/section/home-group.tsx
+++ b/src/pages/home/components/section/home-group.tsx
@@ -1,4 +1,4 @@
-import HomeSectionLayout from '@pages/home/components/layout/home-section-layout';
+import SectionLayout from '@components/section-layout';
 import GroupCard from '@pages/home/components/card/group-card';
 import type { IGroupCard } from '@pages/home/types/home.types';
 
@@ -12,7 +12,7 @@ interface HomeGroupProps {
 
 export default function HomeGroup({ title, data, linkText, isLoading, onLinkClick }: HomeGroupProps) {
   return (
-    <HomeSectionLayout
+    <SectionLayout
       title={title}
       linkText={linkText}
       onLinkClick={onLinkClick}
@@ -32,6 +32,6 @@ export default function HomeGroup({ title, data, linkText, isLoading, onLinkClic
           />
         ))}
       </div>
-    </HomeSectionLayout>
+    </SectionLayout>
   );
 }

--- a/src/pages/home/components/section/home-loan.tsx
+++ b/src/pages/home/components/section/home-loan.tsx
@@ -1,4 +1,4 @@
-import HomeSectionLayout from '@pages/home/components/layout/home-section-layout';
+import SectionLayout from '@components/section-layout';
 import { useKeenSlider } from 'keen-slider/react';
 import BookCard from '@pages/home/components/card/book-card';
 import type { IBookCard } from '@pages/home/types/home.types';
@@ -21,7 +21,7 @@ export default function HomeLoan({ title, data, linkText, isLoading = false, onL
   });
 
   return (
-    <HomeSectionLayout
+    <SectionLayout
       title={title}
       linkText={linkText}
       onLinkClick={onLinkClick}
@@ -43,6 +43,6 @@ export default function HomeLoan({ title, data, linkText, isLoading = false, onL
           ))}
         </div>
       </div>
-    </HomeSectionLayout>
+    </SectionLayout>
   );
 }

--- a/src/pages/home/components/section/home-reservation.tsx
+++ b/src/pages/home/components/section/home-reservation.tsx
@@ -1,4 +1,4 @@
-import HomeSectionLayout from '@pages/home/components/layout/home-section-layout';
+import SectionLayout from '@components/section-layout';
 import { useKeenSlider } from 'keen-slider/react';
 import BookCard from '@pages/home/components/card/book-card';
 import type { IBookCard } from '@pages/home/types/home.types';
@@ -26,7 +26,7 @@ export default function HomeReservation({
     },
   });
   return (
-    <HomeSectionLayout
+    <SectionLayout
       title={title}
       linkText={linkText}
       onLinkClick={onLinkClick}
@@ -48,6 +48,6 @@ export default function HomeReservation({
           ))}
         </div>
       </div>
-    </HomeSectionLayout>
+    </SectionLayout>
   );
 }

--- a/src/pages/home/home-page.tsx
+++ b/src/pages/home/home-page.tsx
@@ -51,7 +51,7 @@ export default function HomePage() {
 
     return (
       <div className='flex-row-center gap-[1.5rem] px-[2rem]'>
-        <div className='h-[12.8rem] min-h-[12.8rem] w-full flex-col gap-[1.5rem] rounded-[0.8rem] bg-white p-[2rem]'>
+        <div className='h-[12.8rem] min-h-[12.8rem] w-full flex-col gap-[1.5rem] rounded-[8px] bg-white p-[2rem]'>
           <div className='flex-row-between'>
             <h1 className='title5 text-gray-900'>보유 포인트</h1>
             <h1 className='title5 text-secondary-900'>1000p</h1>
@@ -59,9 +59,9 @@ export default function HomePage() {
           <h2 className='body5 text-gray-700'>
             <span className='text-primary-900'>9000p</span> 더 모으면 상품권으로 교환할 수 있어요!
           </h2>
-          <div className='relative h-[1.2rem] rounded-[2rem] bg-gray-100'>
+          <div className='relative h-[1.2rem] rounded-[20px] bg-gray-100'>
             <div
-              className='bg-secondary-900 h-full min-h-[1.2rem] rounded-[2rem] transition-all duration-300'
+              className='bg-secondary-900 h-full min-h-[1.2rem] rounded-[20px] transition-all duration-300'
               style={{ width: `${progressPercentage}%` }}
             ></div>
           </div>

--- a/src/pages/home/reservation-page.tsx
+++ b/src/pages/home/reservation-page.tsx
@@ -15,7 +15,7 @@ export default function ReservationPage() {
   }, []);
 
   const renderNotice = () => (
-    <div className='bg-secondary-100 flex-col gap-[1.2rem] rounded-[0.4rem] p-[1.6rem] text-gray-600'>
+    <div className='bg-secondary-100 flex-col gap-[1.2rem] rounded-[4px] p-[1.6rem] text-gray-600'>
       <div className='flex-items-center gap-[0.4rem]'>
         <Icon name='caution' className='text-gray-600' size={1.6} />
 

--- a/src/pages/library/book-detail-page.tsx
+++ b/src/pages/library/book-detail-page.tsx
@@ -5,6 +5,7 @@ import Icon from '@components/icon';
 import { useCart } from '@pages/library/hooks/useCart';
 import type { IBookDetail } from '@pages/library/types/library.types';
 import Button from '@components/button/button';
+import { BOOK_DETAIL_LABELS } from '@pages/library/constants/book-detail';
 
 export default function BookDetailPage() {
   const { bookId } = useParams<{ bookId: string }>();
@@ -48,7 +49,7 @@ export default function BookDetailPage() {
   };
 
   if (!book) {
-    return <div>Loading...</div>;
+    return <div>{BOOK_DETAIL_LABELS.loading}</div>;
   }
 
   const bookDetailHeader = () => {
@@ -64,9 +65,15 @@ export default function BookDetailPage() {
           <span className='flex-row-center caption5 bg-gray-100 px-[0.7rem] text-gray-600'>{book.publisher}</span>
         </span>
         <span className='flex-items-center caption5 gap-[0.5rem] text-gray-600'>
-          <p>최대 반납기한 {book.maxDays}일</p>
+          <p>
+            {BOOK_DETAIL_LABELS.maxDays} {book.maxDays}
+            {BOOK_DETAIL_LABELS.maxDaysUnit}
+          </p>
           <p>|</p>
-          <p>보증금 {book.deposit}p</p>
+          <p>
+            {BOOK_DETAIL_LABELS.deposit} {book.deposit}
+            {BOOK_DETAIL_LABELS.depositUnit}
+          </p>
         </span>
       </div>
     );
@@ -78,13 +85,13 @@ export default function BookDetailPage() {
         <div className='caption5 max-w-[8.5rem] flex-col gap-[1rem] text-gray-800'>
           {book.genre && (
             <div className='flex-row-between caption5'>
-              <span>장르</span>
+              <span>{BOOK_DETAIL_LABELS.genre}</span>
               <span>{book.genre}</span>
             </div>
           )}
           {book.price && (
             <div className='flex-row-between caption5'>
-              <span>정가</span>
+              <span>{BOOK_DETAIL_LABELS.price}</span>
               <span>{book.price}</span>
             </div>
           )}
@@ -95,7 +102,7 @@ export default function BookDetailPage() {
           </div>
         )}
         <div className='flex-col gap-[1rem]'>
-          <h2 className='caption2 text-gray-800'>도서관 위치</h2>
+          <h2 className='caption2 text-gray-800'>{BOOK_DETAIL_LABELS.mapTitle}</h2>
           <div className='min-h-[33.5rem] max-w-[43rem] min-w-[33.5rem] bg-gray-100'></div>
         </div>
       </div>
@@ -106,7 +113,7 @@ export default function BookDetailPage() {
     return (
       <div className='bg-gray-white shadow-bottom-fixed fixed bottom-0 left-1/2 z-50 w-full max-w-[43rem] -translate-x-1/2 px-[2rem] pt-[1.2rem] pb-[2.5rem]'>
         <Button fullWidth={true} onClick={() => nav('/chat/1')}>
-          대여 요청
+          {BOOK_DETAIL_LABELS.rentalRequest}
         </Button>
       </div>
     );
@@ -125,7 +132,7 @@ export default function BookDetailPage() {
         <button
           onClick={handleCartClick}
           className='flex-row-center absolute right-[1rem] bottom-[1rem] z-1 min-h-[3.2rem] min-w-[3.2rem] cursor-pointer rounded-[0.8rem] bg-gray-50'
-          aria-label='장바구니에 담기'
+          aria-label={BOOK_DETAIL_LABELS.addToCart}
         >
           <Icon name='cart-bag' size={2} className='text-gray-800'></Icon>
         </button>

--- a/src/pages/library/book-detail-page.tsx
+++ b/src/pages/library/book-detail-page.tsx
@@ -131,7 +131,7 @@ export default function BookDetailPage() {
         )}
         <button
           onClick={handleCartClick}
-          className='flex-row-center absolute right-[1rem] bottom-[1rem] z-1 min-h-[3.2rem] min-w-[3.2rem] cursor-pointer rounded-[0.8rem] bg-gray-50'
+          className='flex-row-center absolute right-[1rem] bottom-[1rem] z-1 min-h-[3.2rem] min-w-[3.2rem] cursor-pointer rounded-[8px] bg-gray-50'
           aria-label={BOOK_DETAIL_LABELS.addToCart}
         >
           <Icon name='cart-bag' size={2} className='text-gray-800'></Icon>

--- a/src/pages/library/cart-page.tsx
+++ b/src/pages/library/cart-page.tsx
@@ -6,8 +6,7 @@ import type { ILibraryBook } from '@pages/library/types/library.types';
 import Divider from '@components/divider';
 import Button from '@components/button/button';
 import { useNavigate } from 'react-router-dom';
-
-const CART_STORAGE_KEY = 'library-cart';
+import { CART_STORAGE_KEY, CART_LABELS } from '@pages/library/constants/cart';
 
 export default function CartPage() {
   const [cartBooks, setCartBooks] = useState<ILibraryBook[]>([]);
@@ -44,34 +43,34 @@ export default function CartPage() {
       <div className='mb-[1rem] px-[2rem]'>
         <Input
           id='due-date'
-          label='반납기한을 입력해 주세요.'
-          placeholder='숫자만 입력해 주세요 (ex. 20)'
+          label={CART_LABELS.dueDate}
+          placeholder={CART_LABELS.dueDatePlaceholder}
           value={dueDate}
           onChange={(e) => setDueDate(e.currentTarget.value)}
         />
       </div>
       <Divider />
       <div className='flex-col gap-[1.4rem] px-[3rem]'>
-        <h1 className='caption1 text-gray-900'>최종 결제</h1>
+        <h1 className='caption1 text-gray-900'>{CART_LABELS.finalPayment}</h1>
         <div className='flex-col gap-[0.5rem]'>
           <div className='flex-row-between'>
-            <span className='caption4 text-gray-900'>내 포인트</span>
+            <span className='caption4 text-gray-900'>{CART_LABELS.myPoint}</span>
             <span className='caption2 text-gray-900'>48000</span>
           </div>
           <div className='flex-row-between'>
-            <span className='caption4 text-gray-900'>총 보증금</span>
+            <span className='caption4 text-gray-900'>{CART_LABELS.totalDeposit}</span>
             <span className='caption2 text-gray-900'>2000</span>
           </div>
         </div>
         <Divider />
         <div className='flex-row-between'>
-          <h2 className='caption1 text-gray-900'>총 결제 금액</h2>
+          <h2 className='caption1 text-gray-900'>{CART_LABELS.totalPayment}</h2>
           <span className='body1 text-gray-900'>46000</span>
         </div>
       </div>
       <div className='px-[2rem]'>
         <Button fullWidth={true} onClick={() => nav('/chat/1')}>
-          대여 요청
+          {CART_LABELS.rentalRequest}
         </Button>
       </div>
     </div>

--- a/src/pages/library/cart-page.tsx
+++ b/src/pages/library/cart-page.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import EmptyState from '@components/empty/empty-state';
-import CardLibraryBook from '@pages/library/components/card/card-library-book';
+import LibraryBookCard from '@pages/library/components/card/library-book-card';
 import Input from '@components/input/input';
 import type { ILibraryBook } from '@pages/library/types/library.types';
 import Divider from '@components/divider';
@@ -37,7 +37,7 @@ export default function CartPage() {
     <div className='flex-col gap-[2rem] pt-[2rem]'>
       <div className='flex-col gap-[1rem] px-[2rem]'>
         {cartBooks.map((book) => (
-          <CardLibraryBook key={book.id} book={book} isCart={false} />
+          <LibraryBookCard key={book.id} book={book} isCart={false} />
         ))}
       </div>
       <div className='mb-[1rem] px-[2rem]'>

--- a/src/pages/library/components/card/card-libray.tsx
+++ b/src/pages/library/components/card/card-libray.tsx
@@ -1,11 +1,19 @@
 import Icon from '@components/icon';
 import type { ILibrary } from '@pages/library/types/library.types';
+import { useNavigate } from 'react-router-dom';
+import { ROUTES } from '@routes/routes-config';
 
 interface CardLibraryProps {
   library: ILibrary;
 }
 
 export default function CardLibrary({ library }: CardLibraryProps) {
+  const navigate = useNavigate();
+
+  const handleCardClick = () => {
+    navigate(ROUTES.LIBRARY_DETAIL(library.id.toString()));
+  };
+
   const header = () => {
     return (
       <div className='flex gap-[1rem] rounded-tl-[1rem] rounded-tr-[1rem] p-[1rem]'>
@@ -25,7 +33,7 @@ export default function CardLibrary({ library }: CardLibraryProps) {
     );
   };
   return (
-    <div className='min-h-[50.8rem] cursor-pointer flex-col rounded-[1rem] bg-gray-100'>
+    <div onClick={handleCardClick} className='min-h-[50.8rem] cursor-pointer flex-col rounded-[1rem] bg-gray-100'>
       {header()}
       <div className='flex-row-center h-[31.7rem] w-full overflow-hidden bg-gray-200'>
         {library.coverImgUrl ? (

--- a/src/pages/library/components/card/card-libray.tsx
+++ b/src/pages/library/components/card/card-libray.tsx
@@ -27,7 +27,7 @@ export default function CardLibrary({ library }: CardLibraryProps) {
         </div>
         <div className='flex-col'>
           <h1 className='caption3'>{library.owner}</h1>
-          <h2 className='caption5 text-gray-600'>팔로워 수 {library.followerCount}명</h2>
+          <h2 className='caption5 text-gray-600'>구독자 수 {library.followerCount}명</h2>
         </div>
       </div>
     );

--- a/src/pages/library/components/card/card-libray.tsx
+++ b/src/pages/library/components/card/card-libray.tsx
@@ -1,0 +1,43 @@
+import Icon from '@components/icon';
+import type { ILibrary } from '@pages/library/types/library.types';
+
+interface CardLibraryProps {
+  library: ILibrary;
+}
+
+export default function CardLibrary({ library }: CardLibraryProps) {
+  const header = () => {
+    return (
+      <div className='flex gap-[1rem] rounded-tl-[1rem] rounded-tr-[1rem] p-[1rem]'>
+        {/* 프로필 이미지 */}
+        <div className='bl-[1rem] flex-row-center h-[4rem] w-[4rem] shrink-0 overflow-hidden rounded-full bg-white'>
+          {library.profileImgUrl ? (
+            <img src={library.profileImgUrl} alt={library.owner} className='h-full w-full object-cover' />
+          ) : (
+            <Icon name='logo-alt' size={2} className='text-gray-400' />
+          )}
+        </div>
+        <div className='flex-col'>
+          <h1 className='caption3'>{library.owner}</h1>
+          <h2 className='caption5 text-gray-600'>팔로워 수 {library.followerCount}명</h2>
+        </div>
+      </div>
+    );
+  };
+  return (
+    <div className='min-h-[50.8rem] cursor-pointer flex-col rounded-[1rem] bg-gray-100'>
+      {header()}
+      <div className='flex-row-center h-[31.7rem] w-full overflow-hidden bg-gray-200'>
+        {library.coverImgUrl ? (
+          <img src={library.coverImgUrl} alt={library.name} className='h-full w-full object-cover' />
+        ) : (
+          <Icon name='logo-alt' size={6} className='text-gray-400' />
+        )}
+      </div>
+      <div className='flex-col gap-[1rem] rounded-br-[1rem] rounded-bl-[1rem] px-[1rem] py-[2rem]'>
+        <h1 className='caption2'>{library.name}</h1>
+        <h2 className='caption5'>{library.description}</h2>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/library/components/card/card-reivew.tsx
+++ b/src/pages/library/components/card/card-reivew.tsx
@@ -1,0 +1,69 @@
+import { useState, useRef, useEffect } from 'react';
+import Icon from '@components/icon';
+import type { IReview } from '@pages/library/types/review.types';
+
+interface CardReviewProps {
+  review: IReview;
+}
+
+export default function CardReview({ review }: CardReviewProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [needsExpansion, setNeedsExpansion] = useState(false);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (contentRef.current) {
+      const lineHeight = parseInt(window.getComputedStyle(contentRef.current).lineHeight);
+      const contentHeight = contentRef.current.scrollHeight;
+      const lines = contentHeight / lineHeight;
+      setNeedsExpansion(lines > 3);
+    }
+  }, [review.content]);
+
+  const renderStars = (rating: number) => {
+    return Array.from({ length: rating }, (_, index) => (
+      <span key={index} className='text-system-error text-[1.1rem]'>
+        ★
+      </span>
+    ));
+  };
+
+  return (
+    <div className='flex-col gap-[1.5rem] px-[2rem]'>
+      <div className='flex-row-between'>
+        <div className='flex gap-[1rem]'>
+          {/* 프로필 이미지 섹션 */}
+          <div className='flex-items-center gap-[0.5rem]'>
+            <div className='flex-row-center h-[2rem] w-[2rem] overflow-hidden rounded-full bg-gray-200'>
+              {review.profileImgUrl ? (
+                <img src={review.profileImgUrl} alt={review.nickname} className='h-full w-full object-cover' />
+              ) : (
+                <Icon name='logo-alt' size={1} className='text-gray-400' />
+              )}
+            </div>
+            <h2 className='caption3 text-gray-600'>{review.nickname}</h2>
+          </div>
+          <div className='flex-items-center gap-[0.3rem]'>
+            {renderStars(review.rating)}
+            <span className='caption5 text-gray-700'>{review.rating}점</span>
+            <span className='caption5 text-gray-300'>|</span>
+            <span className='caption5 text-gray-700'>{review.date}</span>
+          </div>
+        </div>
+      </div>
+      <div className='flex-col gap-[0.5rem]'>
+        <div ref={contentRef} className={`body5 ${isExpanded ? '' : 'line-clamp-3'}`}>
+          {review.content}
+        </div>
+        {needsExpansion && (
+          <button
+            onClick={() => setIsExpanded(!isExpanded)}
+            className='caption5 cursor-pointer self-start text-gray-500'
+          >
+            {isExpanded ? '접기' : '더보기'}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/library/components/card/libary-reivew-card.tsx
+++ b/src/pages/library/components/card/libary-reivew-card.tsx
@@ -29,7 +29,7 @@ export default function ReviewCard({ review }: ReviewCardProps) {
   };
 
   return (
-    <div className='flex-col gap-[1.5rem] px-[2rem]'>
+    <div className='flex-col gap-[1.5rem]'>
       <div className='flex-row-between'>
         <div className='flex gap-[1rem]'>
           {/* 프로필 이미지 섹션 */}

--- a/src/pages/library/components/card/libary-reivew-card.tsx
+++ b/src/pages/library/components/card/libary-reivew-card.tsx
@@ -2,11 +2,11 @@ import { useState, useRef, useEffect } from 'react';
 import Icon from '@components/icon';
 import type { IReview } from '@pages/library/types/review.types';
 
-interface CardReviewProps {
+interface ReviewCardProps {
   review: IReview;
 }
 
-export default function CardReview({ review }: CardReviewProps) {
+export default function ReviewCard({ review }: ReviewCardProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const [needsExpansion, setNeedsExpansion] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);

--- a/src/pages/library/components/card/library-book-card.tsx
+++ b/src/pages/library/components/card/library-book-card.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { ROUTES } from '@routes/routes-config';
 import { useCart } from '@pages/library/hooks/useCart';
 
-interface CardLibraryBookProps {
+interface LibraryBookCardProps {
   book: ILibraryBook;
   isCart?: boolean;
 }
@@ -22,7 +22,7 @@ const getStatusInfo = (status: BookStatus) => {
   }
 };
 
-export default function CardLibraryBook({ book, isCart = true }: CardLibraryBookProps) {
+export default function LibraryBookCard({ book, isCart = true }: LibraryBookCardProps) {
   const statusInfo = getStatusInfo(book.status);
   const navigate = useNavigate();
   const { addToCart } = useCart();

--- a/src/pages/library/components/card/library-book-card.tsx
+++ b/src/pages/library/components/card/library-book-card.tsx
@@ -39,10 +39,10 @@ export default function LibraryBookCard({ book, isCart = true }: LibraryBookCard
   return (
     <div
       onClick={handleCardClick}
-      className='flex-items-center relative min-h-[13.8rem] w-full cursor-pointer gap-[1rem] rounded-[1rem] bg-gray-50 px-[1.4rem]'
+      className='flex-items-center relative min-h-[13.8rem] w-full cursor-pointer gap-[1rem] rounded-[10px] bg-gray-50 px-[1.4rem]'
     >
       <div
-        className={`caption5 flex-row-center px-[0.7rem] ${statusInfo.color} absolute top-[2rem] right-[1.5rem] min-h-[1.7rem] min-w-[4.8rem] rounded-[0.2rem] bg-gray-100`}
+        className={`caption5 flex-row-center px-[0.7rem] ${statusInfo.color} absolute top-[2rem] right-[1.5rem] min-h-[1.7rem] min-w-[4.8rem] rounded-[2px] bg-gray-100`}
       >
         {statusInfo.text}
       </div>
@@ -50,7 +50,7 @@ export default function LibraryBookCard({ book, isCart = true }: LibraryBookCard
         {isCart && (
           <button
             onClick={handleCartClick}
-            className='flex-row-center absolute right-[0.5rem] bottom-[0.5rem] z-1 min-h-[3.2rem] min-w-[3.2rem] cursor-pointer rounded-[0.8rem] bg-gray-50'
+            className='flex-row-center absolute right-[0.5rem] bottom-[0.5rem] z-1 min-h-[3.2rem] min-w-[3.2rem] cursor-pointer rounded-[8px] bg-gray-50'
             aria-label='장바구니에 담기'
           >
             <Icon name='cart-bag' size={2} className='text-gray-800'></Icon>
@@ -77,7 +77,7 @@ export default function LibraryBookCard({ book, isCart = true }: LibraryBookCard
           </div>
         </div>
         <div className='flex-col gap-[0.3rem]'>
-          <p className='flex-row-center caption5 max-w-[7.4rem] rounded-[0.2rem] bg-gray-100 text-gray-600'>
+          <p className='flex-row-center caption5 max-w-[7.4rem] rounded-[2px] bg-gray-100 text-gray-600'>
             {book.dueDate}
           </p>
           <h3 className='caption5 flex gap-[0.5rem] text-gray-600'>

--- a/src/pages/library/components/card/library-card.tsx
+++ b/src/pages/library/components/card/library-card.tsx
@@ -16,7 +16,7 @@ export default function LibraryCard({ library }: LibraryCardProps) {
 
   const header = () => {
     return (
-      <div className='flex gap-[1rem] rounded-tl-[1rem] rounded-tr-[1rem] p-[1rem]'>
+      <div className='flex gap-[1rem] rounded-tl-[10px] rounded-tr-[10px] p-[1rem]'>
         {/* 프로필 이미지 */}
         <div className='bl-[1rem] flex-row-center h-[4rem] w-[4rem] shrink-0 overflow-hidden rounded-full bg-white'>
           {library.profileImgUrl ? (
@@ -33,7 +33,7 @@ export default function LibraryCard({ library }: LibraryCardProps) {
     );
   };
   return (
-    <div onClick={handleCardClick} className='min-h-[50.8rem] cursor-pointer flex-col rounded-[1rem] bg-gray-100'>
+    <div onClick={handleCardClick} className='min-h-[50.8rem] cursor-pointer flex-col rounded-[10px] bg-gray-100'>
       {header()}
       <div className='flex-row-center h-[31.7rem] w-full overflow-hidden bg-gray-200'>
         {library.coverImgUrl ? (
@@ -42,7 +42,7 @@ export default function LibraryCard({ library }: LibraryCardProps) {
           <Icon name='logo-alt' size={6} className='text-gray-400' />
         )}
       </div>
-      <div className='flex-col gap-[1rem] rounded-br-[1rem] rounded-bl-[1rem] px-[1rem] py-[2rem]'>
+      <div className='flex-col gap-[1rem] rounded-br-[10px] rounded-bl-[10px] px-[1rem] py-[2rem]'>
         <h1 className='caption2'>{library.name}</h1>
         <h2 className='caption5'>{library.description}</h2>
       </div>

--- a/src/pages/library/components/card/library-card.tsx
+++ b/src/pages/library/components/card/library-card.tsx
@@ -3,11 +3,11 @@ import type { ILibrary } from '@pages/library/types/library.types';
 import { useNavigate } from 'react-router-dom';
 import { ROUTES } from '@routes/routes-config';
 
-interface CardLibraryProps {
+interface LibraryCardProps {
   library: ILibrary;
 }
 
-export default function CardLibrary({ library }: CardLibraryProps) {
+export default function LibraryCard({ library }: LibraryCardProps) {
   const navigate = useNavigate();
 
   const handleCardClick = () => {

--- a/src/pages/library/components/library-rating-section.tsx
+++ b/src/pages/library/components/library-rating-section.tsx
@@ -1,0 +1,36 @@
+import Icon from '@components/icon';
+
+interface LibraryRatingSectionProps {
+  rating: number;
+  reviewCount: number;
+  favoriteCount: number;
+  onFavoriteClick: () => void;
+}
+
+export default function LibraryRatingSection({
+  rating,
+  reviewCount,
+  favoriteCount,
+  onFavoriteClick,
+}: LibraryRatingSectionProps) {
+  const starCount = Math.floor(rating);
+  const stars = '★'.repeat(starCount);
+
+  return (
+    <div className='flex-row-between'>
+      <div className='flex-items-center gap-[1rem]'>
+        <h1 className='title1'>{rating}</h1>
+        <h2 className='caption1'>{reviewCount}개</h2>
+        <span className='text-system-error ml-[0.5rem] text-[1.6rem]'>{stars}</span>
+      </div>
+      <button
+        onClick={onFavoriteClick}
+        className='flex-items-center cursor-pointer flex-col gap-[0.4rem]'
+        type='button'
+      >
+        <Icon name='heart' className='text-system-error' size={2.4} aria-label='즐겨찾기 버튼' />
+        <h2 className='caption2 text-gray-white'>{favoriteCount}</h2>
+      </button>
+    </div>
+  );
+}

--- a/src/pages/library/components/section/section-booklist.tsx
+++ b/src/pages/library/components/section/section-booklist.tsx
@@ -2,7 +2,7 @@ import { BOOK_SORT_OPTIONS, type BookSort } from '@components/dropdown/constants
 import SelectDropdown from '@components/dropdown/select-dropdown';
 import Icon from '@components/icon';
 import { useState, useMemo } from 'react';
-import CardLibraryBook from '@pages/library/components/card/card-library-book';
+import LibraryBookCard from '@pages/library/components/card/library-book-card';
 import { useLibraryData } from '@pages/library/hooks/useLibraryData';
 
 export default function BookList() {
@@ -48,7 +48,7 @@ export default function BookList() {
         {isLoading ? (
           <div className='text-center'>로딩 중...</div>
         ) : sortedBooks.length > 0 ? (
-          sortedBooks.map((book) => <CardLibraryBook key={book.id} book={book} />)
+          sortedBooks.map((book) => <LibraryBookCard key={book.id} book={book} />)
         ) : (
           <div className='text-center text-gray-500'>대출할 수 있는 책이 없습니다.</div>
         )}

--- a/src/pages/library/components/section/section-booklist.tsx
+++ b/src/pages/library/components/section/section-booklist.tsx
@@ -7,7 +7,7 @@ import { useLibraryData } from '@pages/library/hooks/useLibraryData';
 
 export default function BookList() {
   const [bookSort, setBookSort] = useState<BookSort>('recent');
-  const { books, isLoading } = useLibraryData();
+  const { books } = useLibraryData();
 
   const sortedBooks = useMemo(() => {
     if (!books.length) return [];
@@ -45,9 +45,7 @@ export default function BookList() {
     <div className='flex-col gap-[0.4rem] pt-[0.4rem]'>
       {BookListOptions()}
       <div className='flex-col gap-[1rem] px-[2rem]'>
-        {isLoading ? (
-          <div className='text-center'>로딩 중...</div>
-        ) : sortedBooks.length > 0 ? (
+        {sortedBooks.length > 0 ? (
           sortedBooks.map((book) => <LibraryBookCard key={book.id} book={book} />)
         ) : (
           <div className='text-center text-gray-500'>대출할 수 있는 책이 없습니다.</div>

--- a/src/pages/library/components/section/section-library-rating.tsx
+++ b/src/pages/library/components/section/section-library-rating.tsx
@@ -1,18 +1,13 @@
 import Icon from '@components/icon';
 
-interface LibraryRatingSectionProps {
+interface LibraryRatingProps {
   rating: number;
   reviewCount: number;
   favoriteCount: number;
   onFavoriteClick: () => void;
 }
 
-export default function LibraryRatingSection({
-  rating,
-  reviewCount,
-  favoriteCount,
-  onFavoriteClick,
-}: LibraryRatingSectionProps) {
+export default function LibraryRating({ rating, reviewCount, favoriteCount, onFavoriteClick }: LibraryRatingProps) {
   const starCount = Math.floor(rating);
   const stars = '★'.repeat(starCount);
 

--- a/src/pages/library/components/section/section-librarylist.tsx
+++ b/src/pages/library/components/section/section-librarylist.tsx
@@ -76,7 +76,7 @@ export default function LibraryList() {
         </div>
         <div
           onClick={() => navigate(ROUTES.LIBRARY_DETAIL('my'))}
-          className='caption3 flex-row-center bg-gray-white cursor-pointer rounded-[0.8rem] border border-gray-300 px-[1.3rem] py-[0.8rem]'
+          className='caption3 flex-row-center bg-gray-white cursor-pointer rounded-[8px] border border-gray-300 px-[1.3rem] py-[0.8rem]'
         >
           {LIBRARY_LIST_LABELS.myLibrary}
         </div>

--- a/src/pages/library/components/section/section-librarylist.tsx
+++ b/src/pages/library/components/section/section-librarylist.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import LibraryCard from '../card/library-card';
+import LibraryCard from '@pages/library/components/card/library-card';
 import type { ILibrary } from '@pages/library/types/library.types';
 import { LIBRARY_LIST_LABELS, type LibraryListTab } from '@pages/library/constants/library-list';
 import { useNavigate } from 'react-router-dom';

--- a/src/pages/library/components/section/section-librarylist.tsx
+++ b/src/pages/library/components/section/section-librarylist.tsx
@@ -2,8 +2,11 @@ import { useEffect, useMemo, useState } from 'react';
 import CardLibrary from '../card/card-libray';
 import type { ILibrary } from '@pages/library/types/library.types';
 import { LIBRARY_LIST_LABELS, type LibraryListTab } from '@pages/library/constants/library-list';
+import { useNavigate } from 'react-router-dom';
+import { ROUTES } from '@routes/routes-config';
 
 export default function LibraryList() {
+  const navigate = useNavigate();
   const [libraries, setLibraries] = useState<ILibrary[]>([]);
   const [activeTab, setActiveTab] = useState<LibraryListTab>('recommended');
 
@@ -71,7 +74,10 @@ export default function LibraryList() {
             {LIBRARY_LIST_LABELS.favorite}
           </span>
         </div>
-        <div className='caption3 flex-row-center bg-gray-white rounded-[0.8rem] border border-gray-300 px-[1.3rem] py-[0.8rem]'>
+        <div
+          onClick={() => navigate(ROUTES.LIBRARY_DETAIL('my'))}
+          className='caption3 flex-row-center bg-gray-white cursor-pointer rounded-[0.8rem] border border-gray-300 px-[1.3rem] py-[0.8rem]'
+        >
           {LIBRARY_LIST_LABELS.myLibrary}
         </div>
       </div>

--- a/src/pages/library/components/section/section-librarylist.tsx
+++ b/src/pages/library/components/section/section-librarylist.tsx
@@ -1,38 +1,84 @@
-import {
-  LIB_SORT_OPTIONS,
-  RENT_STATUS_OPTIONS,
-  type LibSort,
-  type RentStatus,
-} from '@components/dropdown/constants/select-options';
-import SelectDropdown from '@components/dropdown/select-dropdown';
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import CardLibrary from '../card/card-libray';
+import type { ILibrary } from '@pages/library/types/library.types';
+import { LIBRARY_LIST_LABELS, type LibraryListTab } from '@pages/library/constants/library-list';
 
 export default function LibraryList() {
-  const [libSort, setLibSort] = useState<LibSort>('recent');
-  const [rentStatus, setRentStatus] = useState<RentStatus>('pending');
+  const [libraries, setLibraries] = useState<ILibrary[]>([]);
+  const [activeTab, setActiveTab] = useState<LibraryListTab>('recommended');
+
+  useEffect(() => {
+    const mockLibraries: ILibrary[] = [
+      {
+        id: 1,
+        name: '우리 도서관을 소개합니다!',
+        owner: 'changchangwoo',
+        followerCount: 14,
+        description: '여기에 도서관 소개글이 작성됩니다. 도서관 소유자가 자유롭게 도서관 소개글을 작성할 수 있습니다.',
+        profileImgUrl: undefined,
+        coverImgUrl: undefined,
+        isRecommended: true,
+        isFavorite: false,
+      },
+      {
+        id: 2,
+        name: '동네 작은 책방',
+        owner: 'bookLover88',
+        followerCount: 32,
+        description: '책을 사랑하는 사람들이 모이는 따뜻한 공간입니다. 다양한 장르의 책들을 보유하고 있어요.',
+        profileImgUrl: 'https://picsum.photos/330/330?random=2',
+        coverImgUrl: 'https://picsum.photos/330/330?random=4',
+        isRecommended: true,
+        isFavorite: true,
+      },
+      {
+        id: 3,
+        name: '동네 작은 책방',
+        owner: 'bookLover99',
+        followerCount: 32,
+        description: '책을 사랑하는 사람들이 모이는 따뜻한 공간입니다. 다양한 장르의 책들을 보유하고 있어요.',
+        profileImgUrl: undefined,
+        coverImgUrl: 'https://picsum.photos/330/330?random=2',
+        isRecommended: false,
+        isFavorite: true,
+      },
+    ];
+    setLibraries(mockLibraries);
+  }, []);
+
+  const filteredLibraries = useMemo(() => {
+    return libraries.filter((library) => {
+      if (activeTab === 'recommended') return library.isRecommended;
+      if (activeTab === 'favorite') return library.isFavorite;
+      return true;
+    });
+  }, [libraries, activeTab]);
 
   return (
-    <div className='flex-col gap-[1.2rem]'>
-      <div className='flex-row-between'>
-        <div className='flex items-center gap-[1.2rem]'>
-          <SelectDropdown
-            triggerLabel={libSort === 'recent' ? '최신순' : libSort === 'distance' ? '거리순' : '인기순'}
-            value={libSort}
-            onChange={setLibSort}
-            options={LIB_SORT_OPTIONS}
-            variant='title'
-            align='start'
-          />
+    <div className='flex-col gap-[1.2rem] py-[2rem]'>
+      <div className='flex-row-between px-[2rem]'>
+        <div className='title6 flex gap-[1.5rem]'>
+          <span
+            onClick={() => setActiveTab('recommended')}
+            className={`cursor-pointer ${activeTab === 'recommended' ? 'text-gray-900' : 'text-gray-500'}`}
+          >
+            {LIBRARY_LIST_LABELS.recommended}
+          </span>
+          <span
+            onClick={() => setActiveTab('favorite')}
+            className={`cursor-pointer ${activeTab === 'favorite' ? 'text-gray-900' : 'text-gray-500'}`}
+          >
+            {LIBRARY_LIST_LABELS.favorite}
+          </span>
         </div>
-
-        <SelectDropdown
-          variant='chip'
-          value={rentStatus}
-          onChange={setRentStatus}
-          options={RENT_STATUS_OPTIONS}
-          align='end'
-          menuWidthRem={12}
-        />
+        <div className='caption3 flex-row-center bg-gray-white rounded-[0.8rem] border border-gray-300 px-[1.3rem] py-[0.8rem]'>
+          {LIBRARY_LIST_LABELS.myLibrary}
+        </div>
+      </div>
+      <div className='flex-col gap-[2rem] px-[2rem]'>
+        {filteredLibraries.map((library) => (
+          <CardLibrary key={library.id} library={library} />
+        ))}
       </div>
     </div>
   );

--- a/src/pages/library/components/section/section-librarylist.tsx
+++ b/src/pages/library/components/section/section-librarylist.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import CardLibrary from '../card/card-libray';
+import LibraryCard from '../card/library-card';
 import type { ILibrary } from '@pages/library/types/library.types';
 import { LIBRARY_LIST_LABELS, type LibraryListTab } from '@pages/library/constants/library-list';
 import { useNavigate } from 'react-router-dom';
@@ -83,7 +83,7 @@ export default function LibraryList() {
       </div>
       <div className='flex-col gap-[2rem] px-[2rem]'>
         {filteredLibraries.map((library) => (
-          <CardLibrary key={library.id} library={library} />
+          <LibraryCard key={library.id} library={library} />
         ))}
       </div>
     </div>

--- a/src/pages/library/constants/book-detail.ts
+++ b/src/pages/library/constants/book-detail.ts
@@ -1,0 +1,12 @@
+export const BOOK_DETAIL_LABELS = {
+  genre: '장르',
+  price: '정가',
+  maxDays: '최대 반납기한',
+  maxDaysUnit: '일',
+  deposit: '보증금',
+  depositUnit: 'p',
+  mapTitle: '도서관 위치',
+  rentalRequest: '대여 요청',
+  addToCart: '장바구니에 담기',
+  loading: 'Loading...',
+} as const;

--- a/src/pages/library/constants/cart.ts
+++ b/src/pages/library/constants/cart.ts
@@ -1,0 +1,11 @@
+export const CART_STORAGE_KEY = 'library-cart';
+
+export const CART_LABELS = {
+  dueDate: '반납기한을 입력해 주세요.',
+  dueDatePlaceholder: '숫자만 입력해 주세요 (ex. 20)',
+  finalPayment: '최종 결제',
+  myPoint: '내 포인트',
+  totalDeposit: '총 보증금',
+  totalPayment: '총 결제 금액',
+  rentalRequest: '대여 요청',
+} as const;

--- a/src/pages/library/constants/library-detail.ts
+++ b/src/pages/library/constants/library-detail.ts
@@ -1,14 +1,4 @@
 export const LIBRARY_DETAIL = {
-  HEADER: {
-    NAME: '예제 도서관',
-    HOURS: '영업시간 : 08:00 ~ 24:00, 월화수목금',
-    RATING: 4.8,
-    REVIEW_COUNT: 100,
-  },
-  DESCRIPTION: {
-    TITLE: '우리 도서관을 소개합니다!',
-    CONTENT: '여기에 도서관 소개글이 작성됩니다. 도서관 소유자가 자유롭게 도서관 소개글을 작성할 수 있습니다.',
-  },
   REWARD: {
     TITLE: '혜택안내',
     POINT_LABEL: '포인트 적립',

--- a/src/pages/library/constants/library-detail.ts
+++ b/src/pages/library/constants/library-detail.ts
@@ -1,0 +1,27 @@
+export const LIBRARY_DETAIL = {
+  HEADER: {
+    NAME: '예제 도서관',
+    HOURS: '영업시간 : 08:00 ~ 24:00, 월화수목금',
+    RATING: 4.8,
+    REVIEW_COUNT: 100,
+  },
+  DESCRIPTION: {
+    TITLE: '우리 도서관을 소개합니다!',
+    CONTENT: '여기에 도서관 소개글이 작성됩니다. 도서관 소유자가 자유롭게 도서관 소개글을 작성할 수 있습니다.',
+  },
+  REWARD: {
+    TITLE: '혜택안내',
+    POINT_LABEL: '포인트 적립',
+    POINT_DESCRIPTION: '1% BookLink 포인트 적립',
+  },
+  SECTIONS: {
+    BOOK_LIST: {
+      TITLE: '책장',
+      LINK_TEXT: '전체보기 →',
+    },
+    REVIEW: {
+      TITLE: '리뷰',
+      LINK_TEXT: '전체보기 →',
+    },
+  },
+} as const;

--- a/src/pages/library/constants/library-list.ts
+++ b/src/pages/library/constants/library-list.ts
@@ -1,0 +1,9 @@
+export const LIBRARY_LIST_LABELS = {
+  recommended: '추천',
+  favorite: '즐겨찾기',
+  myLibrary: '내 도서관',
+} as const;
+
+export type LibraryListTab = 'recommended' | 'favorite';
+
+export const LIBRARY_LIST_TABS: LibraryListTab[] = ['recommended', 'favorite'];

--- a/src/pages/library/hooks/useLibraryBooks.ts
+++ b/src/pages/library/hooks/useLibraryBooks.ts
@@ -1,0 +1,84 @@
+import { useState, useEffect } from 'react';
+import type { ILibraryBook } from '@pages/library/types/library.types';
+
+const sampleImages = [
+  'https://picsum.photos/200/300?random=1',
+  'https://picsum.photos/200/300?random=2',
+  'https://picsum.photos/200/300?random=3',
+  'https://picsum.photos/200/300?random=4',
+];
+
+const bookTitles = [
+  'IQ84',
+  '노르웨이의 숲',
+  '1984',
+  '어린왕자',
+  '해리포터와 마법사의 돌',
+  '데미안',
+  '카라마조프 가의 형제들',
+  '위대한 개츠비',
+  '살인자의 기억법',
+  '82년생 김지영',
+  '코스모스',
+  '사피엔스',
+];
+
+const authors = [
+  '무라카미 하루키',
+  '조지 오웰',
+  '생텍쥐페리',
+  'J.K. 롤링',
+  '헤르만 헤세',
+  '도스토예프스키',
+  'F. 스콧 피츠제럴드',
+  '김영하',
+  '조남주',
+  '칼 세이건',
+  '유발 하라리',
+];
+
+const libraries = ['북북 도서관', '서울 도서관', '강남 도서관', '홍대 도서관'];
+
+const statuses: Array<'available' | 'rented' | 'reserved'> = ['available', 'rented', 'reserved'];
+
+const generateDummyLibraryBooks = (count: number = 7): ILibraryBook[] => {
+  return Array.from({ length: count }, (_, index) => ({
+    id: index + 1,
+    title: bookTitles[Math.floor(Math.random() * bookTitles.length)],
+    author: authors[Math.floor(Math.random() * authors.length)],
+    library: libraries[Math.floor(Math.random() * libraries.length)],
+    dueDate: `${Math.floor(Math.random() * 12) + 1}월 ${Math.floor(Math.random() * 28) + 1}일 ~ ${Math.floor(Math.random() * 12) + 1}월 ${Math.floor(Math.random() * 28) + 1}일`,
+    maxDays: Math.floor(Math.random() * 30) + 7,
+    deposit: Math.floor(Math.random() * 5) * 1000 + 3000,
+    status: statuses[Math.floor(Math.random() * statuses.length)],
+    imgUrl: Math.random() > 0.3 ? sampleImages[Math.floor(Math.random() * sampleImages.length)] : undefined,
+  }));
+};
+
+const fetchLibraryBooks = async (): Promise<ILibraryBook[]> => {
+  // await new Promise((resolve) => setTimeout(resolve, 800));
+  return generateDummyLibraryBooks(7);
+};
+
+export const useLibraryBooks = () => {
+  const [books, setBooks] = useState<ILibraryBook[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadBooks = async () => {
+      try {
+        const data = await fetchLibraryBooks();
+        setBooks(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Unknown error occurred');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadBooks();
+  }, []);
+
+  return { books, isLoading, error };
+};

--- a/src/pages/library/hooks/useLibraryData.ts
+++ b/src/pages/library/hooks/useLibraryData.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import type { ILibraryBook, ILibraryData, BookStatus } from '../types/library.types';
+import type { ILibraryBook, ILibraryData, BookStatus } from '@pages/library/types/library.types';
 
 const sampleImages = [
   'https://picsum.photos/200/300?random=1',

--- a/src/pages/library/hooks/useLibraryDetailData.ts
+++ b/src/pages/library/hooks/useLibraryDetailData.ts
@@ -90,6 +90,7 @@ export interface ILibraryInfo {
   hours: string;
   rating: number;
   reviewCount: number;
+  favoriteCount: number;
   imageUrl?: string;
   description: {
     title: string;
@@ -109,6 +110,7 @@ const fetchLibraryInfo = async (): Promise<ILibraryInfo> => {
     hours: '영업시간 : 08:00 ~ 24:00, 월화수목금',
     rating: 4.8,
     reviewCount: 100,
+    favoriteCount: 256,
     imageUrl: 'https://picsum.photos/800/480?random=library', // 이미지가 있는 경우
     description: {
       title: '우리 도서관을 소개합니다!',

--- a/src/pages/library/hooks/useLibraryDetailData.ts
+++ b/src/pages/library/hooks/useLibraryDetailData.ts
@@ -1,0 +1,193 @@
+import { useState, useEffect } from 'react';
+import type { IBookCard } from '@pages/home/types/home.types';
+import type { IReview } from '@pages/library/types/review.types';
+
+const sampleImages = [
+  'https://picsum.photos/200/300?random=1',
+  'https://picsum.photos/200/300?random=2',
+  'https://picsum.photos/200/300?random=3',
+  'https://picsum.photos/200/300?random=4',
+];
+
+const bookTitles = [
+  'IQ84',
+  '노르웨이의 숲',
+  '1984',
+  '어린왕자',
+  '해리포터와 마법사의 돌',
+  '데미안',
+  '카라마조프 가의 형제들',
+  '위대한 개츠비',
+  '살인자의 기억법',
+  '82년생 김지영',
+  '코스모스',
+  '사피엔스',
+];
+
+const authors = [
+  '무라카미 하루키',
+  '조지 오웰',
+  '생텍쥐페리',
+  'J.K. 롤링',
+  '헤르만 헤세',
+  '도스토예프스키',
+  'F. 스콧 피츠제럴드',
+  '김영하',
+  '조남주',
+  '칼 세이건',
+  '유발 하라리',
+];
+
+const nicknames = ['책벌레', 'bookLover', '독서광', '북북이', '책마니아', '리더스클럽', '문학소녀'];
+
+const reviewContents = [
+  '너무 읽고 싶었던 책인데 구하기 어려워서 그동안 못 읽었어요. 이번에 대여해 주신 덕분에 소원 성취했습니다! 한 번 더 읽고 싶어서 연장 요청드렸더니 수락해 주셔서 정말 감사했습니다. 도서관장님 적게 일하고 많이 버세요! 그렇다고 너무 잘되시면 배아프니까 적당히만 잘되세요!',
+  '정말 좋은 책이었어요. 도서관장님께 감사드립니다. 다음에도 또 대여하고 싶습니다.',
+  '책 상태도 좋고 대여 과정도 간편했습니다. 추천합니다!',
+  '너무 읽고 싶었던 책인데 구하기 어려워서 그동안 못 읽었어요. 이번에 대여해 주신 덕분에 소원 성취했습니다! 한 번 더 읽고 싶어서 연장 요청드렸더니 수락해 주셔서 정말 감사했습니다. 도서관장님 적게 일하고 많이 버세요! 그렇다고 너무 잘되시면 배아프니까 적당히만 잘되세요!',
+  '기대했던 책인데 실망하지 않았어요. 좋은 책 보유해 주셔서 감사합니다.',
+];
+
+export const generateDummyBooks = (count: number = 7): IBookCard[] => {
+  return Array.from({ length: count }, (_, index) => ({
+    imgurl: Math.random() > 0.3 ? sampleImages[Math.floor(Math.random() * sampleImages.length)] : '',
+    index: index,
+    id: index + 1,
+    title: bookTitles[Math.floor(Math.random() * bookTitles.length)],
+    author: authors[Math.floor(Math.random() * authors.length)],
+    expDate: Math.floor(Math.random() * 10) + 1,
+  }));
+};
+
+export const generateDummyReviews = (count: number = 5): IReview[] => {
+  return Array.from({ length: count }, (_, index) => {
+    const date = new Date();
+    date.setDate(date.getDate() - Math.floor(Math.random() * 30));
+
+    return {
+      id: index + 1,
+      nickname: nicknames[Math.floor(Math.random() * nicknames.length)],
+      rating: Math.floor(Math.random() * 3) + 3, // 3-5점
+      date: date.toISOString().split('T')[0],
+      content: reviewContents[Math.floor(Math.random() * reviewContents.length)],
+      profileImgUrl: Math.random() > 0.5 ? sampleImages[Math.floor(Math.random() * sampleImages.length)] : undefined,
+    };
+  });
+};
+
+const fetchBookData = async (): Promise<IBookCard[]> => {
+  // await new Promise((resolve) => setTimeout(resolve, 800));
+  return generateDummyBooks(7);
+};
+
+const fetchReviewData = async (): Promise<IReview[]> => {
+  // await new Promise((resolve) => setTimeout(resolve, 800));
+  return generateDummyReviews(5);
+};
+
+export interface ILibraryInfo {
+  name: string;
+  hours: string;
+  rating: number;
+  reviewCount: number;
+  imageUrl?: string;
+  description: {
+    title: string;
+    content: string;
+  };
+  reward: {
+    title: string;
+    pointLabel: string;
+    pointDescription: string;
+  };
+}
+
+const fetchLibraryInfo = async (): Promise<ILibraryInfo> => {
+  // await new Promise((resolve) => setTimeout(resolve, 500));
+  return {
+    name: '예제 도서관',
+    hours: '영업시간 : 08:00 ~ 24:00, 월화수목금',
+    rating: 4.8,
+    reviewCount: 100,
+    imageUrl: 'https://picsum.photos/800/480?random=library', // 이미지가 있는 경우
+    description: {
+      title: '우리 도서관을 소개합니다!',
+      content: '여기에 도서관 소개글이 작성됩니다. 도서관 소유자가 자유롭게 도서관 소개글을 작성할 수 있습니다.',
+    },
+    reward: {
+      title: '혜택안내',
+      pointLabel: '포인트 적립',
+      pointDescription: '1% BookLink 포인트 적립',
+    },
+  };
+};
+
+export interface ILibraryDetailData {
+  libraryInfo: ILibraryInfo | null;
+  bookData: IBookCard[];
+  reviewData: IReview[];
+  isLoadingLibraryInfo: boolean;
+  isLoadingBooks: boolean;
+  isLoadingReviews: boolean;
+  error: string | null;
+}
+
+export const useLibraryDetailData = (): ILibraryDetailData => {
+  const [libraryInfo, setLibraryInfo] = useState<ILibraryInfo | null>(null);
+  const [bookData, setBookData] = useState<IBookCard[]>([]);
+  const [reviewData, setReviewData] = useState<IReview[]>([]);
+  const [isLoadingLibraryInfo, setIsLoadingLibraryInfo] = useState(true);
+  const [isLoadingBooks, setIsLoadingBooks] = useState(true);
+  const [isLoadingReviews, setIsLoadingReviews] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadData = async () => {
+      try {
+        const [library, books, reviews] = await Promise.allSettled([
+          fetchLibraryInfo(),
+          fetchBookData(),
+          fetchReviewData(),
+        ]);
+
+        if (library.status === 'fulfilled') {
+          setLibraryInfo(library.value);
+        } else {
+          console.error('Failed to fetch library info:', library.reason);
+        }
+        setIsLoadingLibraryInfo(false);
+
+        if (books.status === 'fulfilled') {
+          setBookData(books.value);
+        } else {
+          console.error('Failed to fetch book data:', books.reason);
+        }
+        setIsLoadingBooks(false);
+
+        if (reviews.status === 'fulfilled') {
+          setReviewData(reviews.value);
+        } else {
+          console.error('Failed to fetch review data:', reviews.reason);
+        }
+        setIsLoadingReviews(false);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Unknown error occurred');
+        setIsLoadingLibraryInfo(false);
+        setIsLoadingBooks(false);
+        setIsLoadingReviews(false);
+      }
+    };
+
+    loadData();
+  }, []);
+
+  return {
+    libraryInfo,
+    bookData,
+    reviewData,
+    isLoadingLibraryInfo,
+    isLoadingBooks,
+    isLoadingReviews,
+    error,
+  };
+};

--- a/src/pages/library/library-book-page.tsx
+++ b/src/pages/library/library-book-page.tsx
@@ -9,7 +9,7 @@ export default function LibraryBookPage() {
       <div className='flex-col gap-[1rem] px-[2rem] pt-[3rem]'>
         <div className='flex-col gap-[1rem]'>
           {Array.from({ length: 7 }).map((_, index) => (
-            <div key={index} className='h-[13.8rem] animate-pulse rounded-[1rem] bg-gray-200'></div>
+            <div key={index} className='h-[13.8rem] animate-pulse rounded-[10px] bg-gray-200'></div>
           ))}
         </div>
       </div>

--- a/src/pages/library/library-book-page.tsx
+++ b/src/pages/library/library-book-page.tsx
@@ -1,5 +1,5 @@
-import LibraryBookCard from './components/card/library-book-card';
-import { useLibraryBooks } from './hooks/useLibraryBooks';
+import LibraryBookCard from '@pages/library/components/card/library-book-card';
+import { useLibraryBooks } from '@pages/library/hooks/useLibraryBooks';
 
 export default function LibraryBookPage() {
   const { books, isLoading } = useLibraryBooks();

--- a/src/pages/library/library-book-page.tsx
+++ b/src/pages/library/library-book-page.tsx
@@ -1,0 +1,28 @@
+import LibraryBookCard from './components/card/library-book-card';
+import { useLibraryBooks } from './hooks/useLibraryBooks';
+
+export default function LibraryBookPage() {
+  const { books, isLoading } = useLibraryBooks();
+
+  if (isLoading) {
+    return (
+      <div className='flex-col gap-[1rem] px-[2rem] pt-[3rem]'>
+        <div className='flex-col gap-[1rem]'>
+          {Array.from({ length: 7 }).map((_, index) => (
+            <div key={index} className='h-[13.8rem] animate-pulse rounded-[1rem] bg-gray-200'></div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className='flex-col gap-[1rem] px-[2rem] pt-[3rem]'>
+      <div className='flex-col gap-[1rem]'>
+        {books.map((book) => (
+          <LibraryBookCard key={book.id} book={book} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/library/library-detail-page.tsx
+++ b/src/pages/library/library-detail-page.tsx
@@ -6,7 +6,7 @@ import 'keen-slider/keen-slider.min.css';
 import ReviewCard from '@pages/library/components/card/libary-reivew-card';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { ROUTES } from '@routes/routes-config';
-import LibraryRatingSection from '@pages/library/components/library-rating-section';
+import LibraryRatingSection from '@pages/library/components/section/section-library-rating';
 
 export default function LibraryDetailPage() {
   const { libraryInfo, bookData, reviewData, isLoadingLibraryInfo, isLoadingBooks, isLoadingReviews, error } =
@@ -169,7 +169,7 @@ export default function LibraryDetailPage() {
         isLoading={isLoadingReviews}
         isEmpty={reviewData.length === 0}
       >
-        <div className='flex-col gap-[2rem]'>
+        <div className='flex-col gap-[2rem] px-[2rem]'>
           {reviewData.map((review) => (
             <ReviewCard key={review.id} review={review} />
           ))}

--- a/src/pages/library/library-detail-page.tsx
+++ b/src/pages/library/library-detail-page.tsx
@@ -1,0 +1,146 @@
+import BookCard from '@pages/home/components/card/book-card';
+import SectionLayout from '@components/section-layout';
+import { useLibraryDetailData } from '@pages/library/hooks/useLibraryDetailData';
+import { useKeenSlider } from 'keen-slider/react';
+import 'keen-slider/keen-slider.min.css';
+import CardReview from './components/card/card-reivew';
+
+export default function LibraryDetailPage() {
+  const { libraryInfo, bookData, reviewData, isLoadingLibraryInfo, isLoadingBooks, isLoadingReviews, error } =
+    useLibraryDetailData();
+  const [sliderRef] = useKeenSlider({
+    mode: 'free-snap',
+    slides: {
+      perView: 'auto',
+      spacing: 10,
+    },
+  });
+
+  console.log(error);
+
+  const header = () => {
+    if (isLoadingLibraryInfo || !libraryInfo) {
+      return (
+        <div className='flex min-h-[30rem] flex-col justify-end gap-[0.5rem] bg-gray-200 p-[2rem] text-white'>
+          <div className='flex-col gap-[0.4rem]'>
+            <div className='h-[2.4rem] w-[20rem] animate-pulse rounded bg-gray-300'></div>
+            <div className='h-[1.6rem] w-[30rem] animate-pulse rounded bg-gray-300'></div>
+          </div>
+        </div>
+      );
+    }
+
+    const starCount = Math.floor(libraryInfo.rating);
+    const stars = '★'.repeat(starCount);
+
+    return (
+      // 이미지 섹션
+      <div
+        className='flex min-h-[30rem] flex-col justify-end gap-[0.5rem] p-[2rem] text-white'
+        style={
+          libraryInfo.imageUrl
+            ? {
+                backgroundImage: `linear-gradient(to bottom, rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0.6)), url(${libraryInfo.imageUrl})`,
+                backgroundSize: 'cover',
+                backgroundPosition: 'center',
+              }
+            : { backgroundColor: 'rgb(229, 231, 235)' }
+        }
+      >
+        <div className='flex-col gap-[0.4rem]'>
+          <h1 className='title3'>{libraryInfo.name}</h1>
+          <h2 className='caption1'>{libraryInfo.hours}</h2>
+        </div>
+        <div className='flex-row-between'>
+          <div className='flex-items-center gap-[1rem]'>
+            <h1 className='title1'>{libraryInfo.rating}</h1>
+            <h2 className='caption1'>{libraryInfo.reviewCount}개</h2>
+            <span className='text-system-error ml-[0.5rem] text-[1.6rem]'>{stars}</span>
+          </div>
+          <div className='flex-col'></div>
+        </div>
+      </div>
+    );
+  };
+
+  const titleDescription = () => {
+    if (isLoadingLibraryInfo || !libraryInfo) return null;
+
+    return (
+      <div className='flex-col gap-[1rem] px-[2rem]'>
+        <h1 className='caption2'>{libraryInfo.description.title}</h1>
+        <h2 className='caption5'>{libraryInfo.description.content}</h2>
+      </div>
+    );
+  };
+
+  const rewardDescription = () => {
+    if (isLoadingLibraryInfo || !libraryInfo) return null;
+
+    return (
+      <div className='flex-col gap-[1rem] px-[2rem]'>
+        <h1 className='caption2'>{libraryInfo.reward.title}</h1>
+        <span className='flex-items-center gap-[0.8rem]'>
+          <h2 className='catpion4 text-gray-700'>{libraryInfo.reward.pointLabel}</h2>
+          <h2 className='caption5'>{libraryInfo.reward.pointDescription}</h2>
+        </span>
+      </div>
+    );
+  };
+
+  const bookListSection = () => {
+    return (
+      <SectionLayout
+        title='책장'
+        linkText='전체보기 →'
+        onLinkClick={() => {}}
+        isLoading={isLoadingBooks}
+        isEmpty={bookData.length === 0}
+      >
+        <div>
+          <div ref={sliderRef} className='keen-slider px-[2rem]'>
+            {bookData.map((book, index) => (
+              <BookCard
+                key={`${book.id}-${index}`}
+                id={book.id}
+                index={index}
+                imgurl={book.imgurl}
+                title={book.title}
+                author={book.author}
+                expDate={book.expDate}
+              />
+            ))}
+          </div>
+        </div>
+      </SectionLayout>
+    );
+  };
+
+  const reviewSection = () => {
+    return (
+      <SectionLayout
+        title='리뷰'
+        linkText='전체보기 →'
+        onLinkClick={() => {}}
+        isLoading={isLoadingReviews}
+        isEmpty={reviewData.length === 0}
+      >
+        <div className='flex-col gap-[2rem]'>
+          {reviewData.map((review) => (
+            <CardReview key={review.id} review={review} />
+          ))}
+        </div>
+      </SectionLayout>
+    );
+  };
+
+  return (
+    <div className='flex-col gap-[3rem]'>
+      {header()}
+      {titleDescription()}
+      {rewardDescription()}
+      {bookListSection()}
+      {reviewSection()}
+    </div>
+  );
+}

--- a/src/pages/library/library-detail-page.tsx
+++ b/src/pages/library/library-detail-page.tsx
@@ -3,8 +3,10 @@ import SectionLayout from '@components/section-layout';
 import { useLibraryDetailData } from '@pages/library/hooks/useLibraryDetailData';
 import { useKeenSlider } from 'keen-slider/react';
 import 'keen-slider/keen-slider.min.css';
-import CardReview from './components/card/card-reivew';
-import Icon from '@components/icon';
+import ReviewCard from './components/card/libary-reivew-card';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { ROUTES } from '@routes/routes-config';
+import LibraryRatingSection from './components/library-rating-section';
 
 export default function LibraryDetailPage() {
   const { libraryInfo, bookData, reviewData, isLoadingLibraryInfo, isLoadingBooks, isLoadingReviews, error } =
@@ -16,11 +18,28 @@ export default function LibraryDetailPage() {
       spacing: 10,
     },
   });
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { id: libraryId } = useParams<{ id: string }>();
+  const isMyPage = location.pathname === '/library/my';
+
+  console.log(libraryId);
 
   console.log(error);
 
   const handleFavoriteClick = () => {
     console.log('즐겨찾기 버튼 클릭');
+  };
+
+  const handleEditClick = () => {
+    navigate(ROUTES.LIBRARY_CREATE);
+  };
+
+  const handleDeleteClick = () => {
+    if (window.confirm('도서관을 삭제하시겠습니까?')) {
+      // 삭제 로직 추가
+      console.log('도서관 삭제');
+    }
   };
 
   const header = () => {
@@ -35,12 +54,9 @@ export default function LibraryDetailPage() {
       );
     }
 
-    const starCount = Math.floor(libraryInfo.rating);
-    const stars = '★'.repeat(starCount);
-
     return (
       <div
-        className='flex min-h-[30rem] flex-col justify-end gap-[0.5rem] p-[2rem] text-white'
+        className='relative flex min-h-[30rem] flex-col justify-end gap-[0.5rem] p-[2rem] text-white'
         style={
           libraryInfo.imageUrl
             ? {
@@ -51,25 +67,33 @@ export default function LibraryDetailPage() {
             : { backgroundColor: 'rgb(229, 231, 235)' }
         }
       >
+        {/* 내 페이지인 경우 */}
+        {isMyPage && (
+          <div className='absolute top-[3rem] right-[2rem] flex gap-[0.3rem]'>
+            <button
+              onClick={handleEditClick}
+              className='flex-row-center caption5 cursor-pointer rounded-[0.2rem] bg-gray-100 px-[0.7rem] text-gray-600'
+            >
+              수정하기
+            </button>
+            <button
+              onClick={handleDeleteClick}
+              className='flex-row-center caption5 text-system-error cursor-pointer rounded-[0.2rem] bg-gray-100 px-[0.7rem]'
+            >
+              삭제하기
+            </button>
+          </div>
+        )}
         <div className='flex-col gap-[0.4rem]'>
           <h1 className='title3'>{libraryInfo.name}</h1>
           <h2 className='caption1'>{libraryInfo.hours}</h2>
         </div>
-        <div className='flex-row-between'>
-          <div className='flex-items-center gap-[1rem]'>
-            <h1 className='title1'>{libraryInfo.rating}</h1>
-            <h2 className='caption1'>{libraryInfo.reviewCount}개</h2>
-            <span className='text-system-error ml-[0.5rem] text-[1.6rem]'>{stars}</span>
-          </div>
-          <button
-            onClick={handleFavoriteClick}
-            className='flex-items-center cursor-pointer flex-col gap-[0.4rem]'
-            type='button'
-          >
-            <Icon name='heart' className='text-system-error' size={2.4} aria-label='즐겨찾기 버튼' />
-            <h2 className='caption2 text-gray-white'>{libraryInfo.favoriteCount}</h2>
-          </button>
-        </div>
+        <LibraryRatingSection
+          rating={libraryInfo.rating}
+          reviewCount={libraryInfo.reviewCount}
+          favoriteCount={libraryInfo.favoriteCount}
+          onFavoriteClick={handleFavoriteClick}
+        />
       </div>
     );
   };
@@ -104,7 +128,12 @@ export default function LibraryDetailPage() {
       <SectionLayout
         title='책장'
         linkText='전체보기 →'
-        onLinkClick={() => {}}
+        onLinkClick={() => {
+          console.log(libraryId);
+          if (libraryId) {
+            navigate(ROUTES.LIBRARY_BOOK(libraryId));
+          }
+        }}
         isLoading={isLoadingBooks}
         isEmpty={bookData.length === 0}
       >
@@ -132,13 +161,17 @@ export default function LibraryDetailPage() {
       <SectionLayout
         title='리뷰'
         linkText='전체보기 →'
-        onLinkClick={() => {}}
+        onLinkClick={() => {
+          if (libraryId) {
+            navigate(ROUTES.LIBRARY_REVIEW(libraryId));
+          }
+        }}
         isLoading={isLoadingReviews}
         isEmpty={reviewData.length === 0}
       >
         <div className='flex-col gap-[2rem]'>
           {reviewData.map((review) => (
-            <CardReview key={review.id} review={review} />
+            <ReviewCard key={review.id} review={review} />
           ))}
         </div>
       </SectionLayout>

--- a/src/pages/library/library-detail-page.tsx
+++ b/src/pages/library/library-detail-page.tsx
@@ -4,6 +4,7 @@ import { useLibraryDetailData } from '@pages/library/hooks/useLibraryDetailData'
 import { useKeenSlider } from 'keen-slider/react';
 import 'keen-slider/keen-slider.min.css';
 import CardReview from './components/card/card-reivew';
+import Icon from '@components/icon';
 
 export default function LibraryDetailPage() {
   const { libraryInfo, bookData, reviewData, isLoadingLibraryInfo, isLoadingBooks, isLoadingReviews, error } =
@@ -17,6 +18,10 @@ export default function LibraryDetailPage() {
   });
 
   console.log(error);
+
+  const handleFavoriteClick = () => {
+    console.log('즐겨찾기 버튼 클릭');
+  };
 
   const header = () => {
     if (isLoadingLibraryInfo || !libraryInfo) {
@@ -34,7 +39,6 @@ export default function LibraryDetailPage() {
     const stars = '★'.repeat(starCount);
 
     return (
-      // 이미지 섹션
       <div
         className='flex min-h-[30rem] flex-col justify-end gap-[0.5rem] p-[2rem] text-white'
         style={
@@ -57,7 +61,14 @@ export default function LibraryDetailPage() {
             <h2 className='caption1'>{libraryInfo.reviewCount}개</h2>
             <span className='text-system-error ml-[0.5rem] text-[1.6rem]'>{stars}</span>
           </div>
-          <div className='flex-col'></div>
+          <button
+            onClick={handleFavoriteClick}
+            className='flex-items-center cursor-pointer flex-col gap-[0.4rem]'
+            type='button'
+          >
+            <Icon name='heart' className='text-system-error' size={2.4} aria-label='즐겨찾기 버튼' />
+            <h2 className='caption2 text-gray-white'>{libraryInfo.favoriteCount}</h2>
+          </button>
         </div>
       </div>
     );

--- a/src/pages/library/library-detail-page.tsx
+++ b/src/pages/library/library-detail-page.tsx
@@ -43,12 +43,12 @@ export default function LibraryDetailPage() {
   };
 
   const header = () => {
-    if (isLoadingLibraryInfo || !libraryInfo) {
+    if (!libraryInfo) {
       return (
         <div className='flex min-h-[30rem] flex-col justify-end gap-[0.5rem] bg-gray-200 p-[2rem] text-white'>
           <div className='flex-col gap-[0.4rem]'>
-            <div className='h-[2.4rem] w-[20rem] animate-pulse rounded bg-gray-300'></div>
-            <div className='h-[1.6rem] w-[30rem] animate-pulse rounded bg-gray-300'></div>
+            <div className='h-[2.4rem] w-[20rem] animate-pulse rounded bg-gray-300' />
+            <div className='h-[1.6rem] w-[30rem] animate-pulse rounded bg-gray-300' />
           </div>
         </div>
       );
@@ -72,13 +72,13 @@ export default function LibraryDetailPage() {
           <div className='absolute top-[3rem] right-[2rem] flex gap-[0.3rem]'>
             <button
               onClick={handleEditClick}
-              className='flex-row-center caption5 cursor-pointer rounded-[0.2rem] bg-gray-100 px-[0.7rem] text-gray-600'
+              className='flex-row-center caption5 cursor-pointer rounded-[2px] bg-gray-100 px-[0.7rem] text-gray-600'
             >
               수정하기
             </button>
             <button
               onClick={handleDeleteClick}
-              className='flex-row-center caption5 text-system-error cursor-pointer rounded-[0.2rem] bg-gray-100 px-[0.7rem]'
+              className='flex-row-center caption5 text-system-error cursor-pointer rounded-[2px] bg-gray-100 px-[0.7rem]'
             >
               삭제하기
             </button>

--- a/src/pages/library/library-detail-page.tsx
+++ b/src/pages/library/library-detail-page.tsx
@@ -3,10 +3,10 @@ import SectionLayout from '@components/section-layout';
 import { useLibraryDetailData } from '@pages/library/hooks/useLibraryDetailData';
 import { useKeenSlider } from 'keen-slider/react';
 import 'keen-slider/keen-slider.min.css';
-import ReviewCard from './components/card/libary-reivew-card';
+import ReviewCard from '@pages/library/components/card/libary-reivew-card';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { ROUTES } from '@routes/routes-config';
-import LibraryRatingSection from './components/library-rating-section';
+import LibraryRatingSection from '@pages/library/components/library-rating-section';
 
 export default function LibraryDetailPage() {
   const { libraryInfo, bookData, reviewData, isLoadingLibraryInfo, isLoadingBooks, isLoadingReviews, error } =

--- a/src/pages/library/library-review-page.tsx
+++ b/src/pages/library/library-review-page.tsx
@@ -1,0 +1,42 @@
+import LibraryRatingSection from './components/library-rating-section';
+import ReviewCard from './components/card/libary-reivew-card';
+import { useLibraryDetailData } from './hooks/useLibraryDetailData';
+
+export default function LibraryReviewPage() {
+  const { libraryInfo, reviewData, isLoadingLibraryInfo, isLoadingReviews } = useLibraryDetailData();
+
+  const handleFavoriteClick = () => {
+    console.log('즐겨찾기 버튼 클릭');
+  };
+
+  if (isLoadingLibraryInfo || isLoadingReviews) {
+    return (
+      <div className='flex-col gap-[2rem] px-[2rem] pt-[3rem]'>
+        <div className='h-[6rem] animate-pulse rounded-[1rem] bg-gray-200'></div>
+        <div className='flex-col gap-[2rem]'>
+          {Array.from({ length: 5 }).map((_, index) => (
+            <div key={index} className='h-[10rem] animate-pulse rounded-[1rem] bg-gray-200'></div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (!libraryInfo) return null;
+
+  return (
+    <div className='flex-col gap-[2rem] px-[2rem] pt-[3rem]'>
+      <LibraryRatingSection
+        rating={libraryInfo.rating}
+        reviewCount={libraryInfo.reviewCount}
+        favoriteCount={libraryInfo.favoriteCount}
+        onFavoriteClick={handleFavoriteClick}
+      />
+      <div className='flex-col gap-[2rem]'>
+        {reviewData.map((review) => (
+          <ReviewCard key={review.id} review={review} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/library/library-review-page.tsx
+++ b/src/pages/library/library-review-page.tsx
@@ -12,10 +12,10 @@ export default function LibraryReviewPage() {
   if (isLoadingLibraryInfo || isLoadingReviews) {
     return (
       <div className='flex-col gap-[2rem] px-[2rem] pt-[3rem]'>
-        <div className='h-[6rem] animate-pulse rounded-[1rem] bg-gray-200'></div>
+        <div className='h-[6rem] animate-pulse rounded-[10px] bg-gray-200'></div>
         <div className='flex-col gap-[2rem]'>
           {Array.from({ length: 5 }).map((_, index) => (
-            <div key={index} className='h-[10rem] animate-pulse rounded-[1rem] bg-gray-200'></div>
+            <div key={index} className='h-[10rem] animate-pulse rounded-[10px] bg-gray-200'></div>
           ))}
         </div>
       </div>

--- a/src/pages/library/library-review-page.tsx
+++ b/src/pages/library/library-review-page.tsx
@@ -1,4 +1,4 @@
-import LibraryRatingSection from '@pages/library/components/library-rating-section';
+import LibraryRatingSection from '@pages/library/components/section/section-library-rating';
 import ReviewCard from '@pages/library/components/card/libary-reivew-card';
 import { useLibraryDetailData } from '@pages/library/hooks/useLibraryDetailData';
 

--- a/src/pages/library/library-review-page.tsx
+++ b/src/pages/library/library-review-page.tsx
@@ -1,6 +1,6 @@
-import LibraryRatingSection from './components/library-rating-section';
-import ReviewCard from './components/card/libary-reivew-card';
-import { useLibraryDetailData } from './hooks/useLibraryDetailData';
+import LibraryRatingSection from '@pages/library/components/library-rating-section';
+import ReviewCard from '@pages/library/components/card/libary-reivew-card';
+import { useLibraryDetailData } from '@pages/library/hooks/useLibraryDetailData';
 
 export default function LibraryReviewPage() {
   const { libraryInfo, reviewData, isLoadingLibraryInfo, isLoadingReviews } = useLibraryDetailData();

--- a/src/pages/library/types/library.types.ts
+++ b/src/pages/library/types/library.types.ts
@@ -34,3 +34,15 @@ export interface IBookDetail {
   latitude?: number;
   longitude?: number;
 }
+
+export interface ILibrary {
+  id: number;
+  name: string;
+  owner: string;
+  followerCount: number;
+  description: string;
+  profileImgUrl?: string;
+  coverImgUrl?: string;
+  isRecommended?: boolean;
+  isFavorite?: boolean;
+}

--- a/src/pages/library/types/review.types.ts
+++ b/src/pages/library/types/review.types.ts
@@ -1,0 +1,14 @@
+export interface IReview {
+  id: number;
+  nickname: string;
+  rating: number;
+  date: string;
+  content: string;
+  profileImgUrl?: string;
+}
+
+export interface IReviewData {
+  reviews: IReview[];
+  isLoading: boolean;
+  error: string | null;
+}

--- a/src/shared/components/section-layout.tsx
+++ b/src/shared/components/section-layout.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from 'react';
+
+interface SectionLayoutProps {
+  title: string;
+  linkText?: string;
+  onLinkClick?: () => void;
+  isLoading?: boolean;
+  isEmpty?: boolean;
+  emptyText?: string;
+  loadingText?: string;
+  children: ReactNode;
+}
+
+export default function SectionLayout({
+  title,
+  linkText = '전체 보기 →',
+  onLinkClick,
+  isLoading = false,
+  isEmpty = false,
+  emptyText = '데이터가 없습니다',
+  loadingText = '데이터를 불러오는 중...',
+  children,
+}: SectionLayoutProps) {
+  return (
+    <section className='flex-col gap-[1.5rem]'>
+      <div className='flex justify-between px-[2rem]'>
+        <h1 className='title5 ml-[0.5rem] text-gray-700'>{title}</h1>
+        <a className='caption5 mt-[0.4rem] cursor-pointer text-gray-400' onClick={onLinkClick}>
+          {linkText}
+        </a>
+      </div>
+      {isLoading ? (
+        <div className='px-[2rem] text-center text-gray-500'>{loadingText}</div>
+      ) : isEmpty ? (
+        <div className='px-[2rem] text-center text-gray-500'>{emptyText}</div>
+      ) : (
+        children
+      )}
+    </section>
+  );
+}

--- a/src/shared/layouts/header-config.ts
+++ b/src/shared/layouts/header-config.ts
@@ -94,6 +94,7 @@ const myLoan: Rule = (path) =>
 // 나의 모임
 const myGroup: Rule = (path) =>
   ROUTES.GROUP && matchPath({ path: ROUTES.GROUP, end: true }, path) ? { left: 'back', title: '나의 모임' } : undefined;
+
 // 도서관 등록
 const libraryCreateRule: Rule = (path) =>
   ROUTES.LIBRARY_CREATE && matchPath({ path: ROUTES.LIBRARY_CREATE, end: true }, path)

--- a/src/shared/routes/router.tsx
+++ b/src/shared/routes/router.tsx
@@ -23,6 +23,8 @@ const RentalPage = lazy(() => import('@pages/home/rental-page'));
 const CartPage = lazy(() => import('@pages/library/cart-page'));
 const BookDetailPage = lazy(() => import('@pages/library/book-detail-page'));
 const LibraryDetailPage = lazy(() => import('@pages/library/library-detail-page'));
+const LibraryBookPage = lazy(() => import('@pages/library/library-book-page'));
+const LibraryReviewPage = lazy(() => import('@pages/library/library-review-page'));
 
 export const router = createBrowserRouter([
   {
@@ -48,6 +50,8 @@ export const router = createBrowserRouter([
       { path: ROUTES.CART, element: <CartPage /> },
       { path: ROUTES.BOOK_DETAIL(':id'), element: <BookDetailPage /> },
       { path: ROUTES.LIBRARY_DETAIL(':id'), element: <LibraryDetailPage /> },
+      { path: ROUTES.LIBRARY_BOOK(':id'), element: <LibraryBookPage /> },
+      { path: ROUTES.LIBRARY_REVIEW(':id'), element: <LibraryReviewPage /> },
     ],
   },
 ]);

--- a/src/shared/routes/router.tsx
+++ b/src/shared/routes/router.tsx
@@ -22,6 +22,7 @@ const GroupPage = lazy(() => import('@pages/home/group-page'));
 const RentalPage = lazy(() => import('@pages/home/rental-page'));
 const CartPage = lazy(() => import('@pages/library/cart-page'));
 const BookDetailPage = lazy(() => import('@pages/library/book-detail-page'));
+const LibraryDetailPage = lazy(() => import('@pages/library/library-detail-page'));
 
 export const router = createBrowserRouter([
   {
@@ -46,6 +47,7 @@ export const router = createBrowserRouter([
       { path: ROUTES.GROUP, element: <GroupPage /> },
       { path: ROUTES.CART, element: <CartPage /> },
       { path: ROUTES.BOOK_DETAIL(':id'), element: <BookDetailPage /> },
+      { path: ROUTES.LIBRARY_DETAIL(':id'), element: <LibraryDetailPage /> },
     ],
   },
 ]);

--- a/src/shared/routes/routes-config.ts
+++ b/src/shared/routes/routes-config.ts
@@ -19,4 +19,5 @@ export const ROUTES = {
   RENTAL: '/rental',
   GROUP: '/group',
   BOOK_DETAIL: (id = ':bookId') => `/book/${id}`,
+  LIBRARY_DETAIL: (id = ':libraryId') => `/library/${id}`,
 };

--- a/src/shared/routes/routes-config.ts
+++ b/src/shared/routes/routes-config.ts
@@ -20,4 +20,6 @@ export const ROUTES = {
   GROUP: '/group',
   BOOK_DETAIL: (id = ':bookId') => `/book/${id}`,
   LIBRARY_DETAIL: (id = ':libraryId') => `/library/${id}`,
+  LIBRARY_BOOK: (id = ':libraryId') => `/library/${id}/book`,
+  LIBRARY_REVIEW: (id = ':libraryId') => `/library/${id}/review`,
 };


### PR DESCRIPTION
## 📝작업 내용

* 도서관 리스트 페이지와 하위 페이지(도서 상세, 도서 책장, 도서 리뷰) 들의 UI를 구현하였습니다.
* 공모 제출기한에 맞춰 UI 구현에 우선순위를 두었습니다. 백엔드 데이터 연동하면서 리팩토링 진행하겠습니다.

## 🐢 변경사항
* 도서 상세 페이지, 도서 상세 책장 페이지, 도서 상세 리뷰 페이지 라우터 파일 변경

```jsx
  LIBRARY_DETAIL: (id = ':libraryId') => `/library/${id}`,
  LIBRARY_BOOK: (id = ':libraryId') => `/library/${id}/book`,
  LIBRARY_REVIEW: (id = ':libraryId') => `/library/${id}/review`,
```

## 📷 스크린샷

<table>
  <tr>
    <td><img width="430" height="919" alt="image" src="https://github.com/user-attachments/assets/33c3c2b9-72ff-461a-a143-1f41f850192a" /></td>
    <td><img width="428" height="920" alt="image" src="https://github.com/user-attachments/assets/88819e8e-59cf-4988-92e1-c02adee9a268" /></td>
    <td><img width="427" height="907" alt="image" src="https://github.com/user-attachments/assets/392a57c3-8f07-41b8-91f4-13d52e7109d6" /></td>
  </tr>
</table>


## 참고
디자인이 아직 진행되지 않았거나, 논의가 필요한 부분은 구현하지 않았습니다. 해당부분은 추후 다시 구현하겠습니다.