### PR TITLE
도서관 카드, 도서관 책장 페이지 카테고리 구현

### DIFF
--- a/src/pages/library/book-detail-page.tsx
+++ b/src/pages/library/book-detail-page.tsx
@@ -49,7 +49,7 @@ export default function BookDetailPage() {
   };
 
   if (!book) {
-    return <div>{BOOK_DETAIL_LABELS.loading}</div>;
+    return;
   }
 
   const bookDetailHeader = () => {

--- a/src/pages/library/components/card/library-card.tsx
+++ b/src/pages/library/components/card/library-card.tsx
@@ -28,8 +28,8 @@ export default function LibraryCard({ library }: LibraryCardProps) {
           <h1 className='caption3'>{library.owner}</h1>
           <h2 className='caption5 text-gray-600'>즐겨찾는 인원 {library.followerCount}명</h2>
         </div>
-        <button className='bg-gray-white caption3 ml-auto cursor-pointer rounded-[8px] border border-gray-300 px-[2.8rem] py-[0.8rem]'>
-          즐겨찾기
+        <button className='ml-auto cursor-pointer'>
+          <Icon name='heart' className='text-system-error' size={2.4} />
         </button>
       </div>
     );

--- a/src/pages/library/components/card/library-card.tsx
+++ b/src/pages/library/components/card/library-card.tsx
@@ -17,7 +17,6 @@ export default function LibraryCard({ library }: LibraryCardProps) {
   const header = () => {
     return (
       <div className='flex gap-[1rem] rounded-tl-[10px] rounded-tr-[10px] p-[1rem]'>
-        {/* 프로필 이미지 */}
         <div className='bl-[1rem] flex-row-center h-[4rem] w-[4rem] shrink-0 overflow-hidden rounded-full bg-white'>
           {library.profileImgUrl ? (
             <img src={library.profileImgUrl} alt={library.owner} className='h-full w-full object-cover' />
@@ -27,25 +26,32 @@ export default function LibraryCard({ library }: LibraryCardProps) {
         </div>
         <div className='flex-col'>
           <h1 className='caption3'>{library.owner}</h1>
-          <h2 className='caption5 text-gray-600'>구독자 수 {library.followerCount}명</h2>
+          <h2 className='caption5 text-gray-600'>즐겨찾는 인원 {library.followerCount}명</h2>
         </div>
+        <button className='bg-gray-white caption3 ml-auto cursor-pointer rounded-[8px] border border-gray-300 px-[2.8rem] py-[0.8rem]'>
+          즐겨찾기
+        </button>
       </div>
     );
   };
   return (
-    <div onClick={handleCardClick} className='min-h-[50.8rem] cursor-pointer flex-col rounded-[10px] bg-gray-100'>
+    <div
+      onClick={handleCardClick}
+      className='min-h-[48.1rem] cursor-pointer flex-col gap-[1.5rem] rounded-[10px] bg-gray-50'
+    >
       {header()}
-      <div className='flex-row-center h-[31.7rem] w-full overflow-hidden bg-gray-200'>
+      <div className='flex-row-center h-[31.7rem] w-full overflow-hidden bg-gray-50'>
         {library.coverImgUrl ? (
           <img src={library.coverImgUrl} alt={library.name} className='h-full w-full object-cover' />
         ) : (
           <Icon name='logo-alt' size={6} className='text-gray-400' />
         )}
       </div>
-      <div className='flex-col gap-[1rem] rounded-br-[10px] rounded-bl-[10px] px-[1rem] py-[2rem]'>
+      <div className='flex-col gap-[1rem] rounded-br-[10px] rounded-bl-[10px] px-[1rem]'>
         <h1 className='caption2'>{library.name}</h1>
         <h2 className='caption5'>{library.description}</h2>
       </div>
+      <div />
     </div>
   );
 }

--- a/src/pages/library/hooks/useLibraryBooks.ts
+++ b/src/pages/library/hooks/useLibraryBooks.ts
@@ -47,7 +47,7 @@ const generateDummyLibraryBooks = (count: number = 7): ILibraryBook[] => {
     title: bookTitles[Math.floor(Math.random() * bookTitles.length)],
     author: authors[Math.floor(Math.random() * authors.length)],
     library: libraries[Math.floor(Math.random() * libraries.length)],
-    dueDate: `${Math.floor(Math.random() * 12) + 1}월 ${Math.floor(Math.random() * 28) + 1}일 ~ ${Math.floor(Math.random() * 12) + 1}월 ${Math.floor(Math.random() * 28) + 1}일`,
+    dueDate: `2025.1${Math.floor(Math.random() * 2) + 1}.0${Math.floor(Math.random() * 9) + 1}`,
     maxDays: Math.floor(Math.random() * 30) + 7,
     deposit: Math.floor(Math.random() * 5) * 1000 + 3000,
     status: statuses[Math.floor(Math.random() * statuses.length)],

--- a/src/pages/library/library-book-page.tsx
+++ b/src/pages/library/library-book-page.tsx
@@ -25,7 +25,7 @@ export default function LibraryBookPage() {
   }
 
   return (
-    <div className='pt-1.5rem] flex-col gap-[1rem] px-[2rem]'>
+    <div className='pt-[1.5rem] flex-col gap-[1rem] px-[2rem]'>
       <SearchBar placeholder={'검색어를 입력해 주세요.'} />
       <button onClick={open} className='body4 flex cursor-pointer items-center gap-[0.4rem] self-end text-gray-900'>
         <span>{BOOK_CATEGORY_OPTIONS.find((opt) => opt.value === selectCategory)?.label}</span>

--- a/src/pages/library/library-book-page.tsx
+++ b/src/pages/library/library-book-page.tsx
@@ -1,8 +1,15 @@
+import { useState } from 'react';
+import Icon from '@components/icon';
+import SelectBottomSheet from '@components/bottom-sheet/select-bottom-sheet';
+import useBottomSheet from '@components/bottom-sheet/hooks/use-bottom-sheet';
 import LibraryBookCard from '@pages/library/components/card/library-book-card';
 import { useLibraryBooks } from '@pages/library/hooks/useLibraryBooks';
+import { BOOK_CATEGORY_OPTIONS, type BookCategory } from '@components/dropdown/constants/select-options';
 
 export default function LibraryBookPage() {
   const { books, isLoading } = useLibraryBooks();
+  const { isOpen, open, close } = useBottomSheet();
+  const [selectCategory, setSelectCategory] = useState<BookCategory>('all');
 
   if (isLoading) {
     return (
@@ -18,11 +25,22 @@ export default function LibraryBookPage() {
 
   return (
     <div className='flex-col gap-[1rem] px-[2rem] pt-[3rem]'>
+      <button onClick={open} className='body4 flex cursor-pointer items-center gap-[0.4rem] self-end text-gray-900'>
+        <span>{BOOK_CATEGORY_OPTIONS.find((opt) => opt.value === selectCategory)?.label}</span>
+        <Icon name='dropdown' size={1.2} />
+      </button>
       <div className='flex-col gap-[1rem]'>
         {books.map((book) => (
           <LibraryBookCard key={book.id} book={book} />
         ))}
       </div>
+      <SelectBottomSheet
+        open={isOpen}
+        onClose={close}
+        options={BOOK_CATEGORY_OPTIONS}
+        value={selectCategory}
+        onChange={setSelectCategory}
+      />
     </div>
   );
 }

--- a/src/pages/library/library-book-page.tsx
+++ b/src/pages/library/library-book-page.tsx
@@ -25,7 +25,7 @@ export default function LibraryBookPage() {
   }
 
   return (
-    <div className='pt-[1.5rem] flex-col gap-[1rem] px-[2rem]'>
+    <div className='flex-col gap-[1rem] px-[2rem] pt-[1.5rem]'>
       <SearchBar placeholder={'검색어를 입력해 주세요.'} />
       <button onClick={open} className='body4 flex cursor-pointer items-center gap-[0.4rem] self-end text-gray-900'>
         <span>{BOOK_CATEGORY_OPTIONS.find((opt) => opt.value === selectCategory)?.label}</span>

--- a/src/pages/library/library-book-page.tsx
+++ b/src/pages/library/library-book-page.tsx
@@ -4,12 +4,13 @@ import SelectBottomSheet from '@components/bottom-sheet/select-bottom-sheet';
 import useBottomSheet from '@components/bottom-sheet/hooks/use-bottom-sheet';
 import LibraryBookCard from '@pages/library/components/card/library-book-card';
 import { useLibraryBooks } from '@pages/library/hooks/useLibraryBooks';
-import { BOOK_CATEGORY_OPTIONS, type BookCategory } from '@components/dropdown/constants/select-options';
+import { BOOK_CATEGORY_OPTIONS } from '@components/dropdown/constants/select-options';
+import SearchBar from '@components/search-bar';
 
 export default function LibraryBookPage() {
   const { books, isLoading } = useLibraryBooks();
   const { isOpen, open, close } = useBottomSheet();
-  const [selectCategory, setSelectCategory] = useState<BookCategory>('all');
+  const [selectCategory, setSelectCategory] = useState<string>('all');
 
   if (isLoading) {
     return (
@@ -24,7 +25,8 @@ export default function LibraryBookPage() {
   }
 
   return (
-    <div className='flex-col gap-[1rem] px-[2rem] pt-[3rem]'>
+    <div className='pt-1.5rem] flex-col gap-[1rem] px-[2rem]'>
+      <SearchBar placeholder={'검색어를 입력해 주세요.'} />
       <button onClick={open} className='body4 flex cursor-pointer items-center gap-[0.4rem] self-end text-gray-900'>
         <span>{BOOK_CATEGORY_OPTIONS.find((opt) => opt.value === selectCategory)?.label}</span>
         <Icon name='dropdown' size={1.2} />

--- a/src/shared/components/dropdown/constants/select-options.ts
+++ b/src/shared/components/dropdown/constants/select-options.ts
@@ -1,6 +1,19 @@
 export type LibSort = 'recent' | 'popular' | 'distance';
 export type BookSort = 'recent' | 'popular';
 export type RentStatus = 'pending' | 'confirmed' | 'stopped';
+export type BookCategory = 'all' | '000' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900';
+export type BookCategoryLabel =
+  | '카테고리 전체'
+  | '총류'
+  | '철학'
+  | '종교'
+  | '사회과학'
+  | '자연과학'
+  | '기술과학'
+  | '예술'
+  | '언어(어학)'
+  | '문학'
+  | '역사';
 
 export const LIB_SORT_OPTIONS: ReadonlyArray<{ value: LibSort; label: string }> = [
   { value: 'recent', label: '최신순' },
@@ -17,4 +30,18 @@ export const RENT_STATUS_OPTIONS: ReadonlyArray<{ value: RentStatus; label: stri
   { value: 'pending', label: '대여 대기' },
   { value: 'confirmed', label: '대여 확정' },
   { value: 'stopped', label: '대여 중단' },
+];
+
+export const BOOK_CATEGORY_OPTIONS: ReadonlyArray<{ value: BookCategory; label: BookCategoryLabel }> = [
+  { value: 'all', label: '카테고리 전체' },
+  { value: '000', label: '총류' },
+  { value: '100', label: '철학' },
+  { value: '200', label: '종교' },
+  { value: '300', label: '사회과학' },
+  { value: '400', label: '자연과학' },
+  { value: '500', label: '기술과학' },
+  { value: '600', label: '예술' },
+  { value: '700', label: '언어(어학)' },
+  { value: '800', label: '문학' },
+  { value: '900', label: '역사' },
 ];


### PR DESCRIPTION
## 📝작업 내용

도서관 카드 컴포넌트 디자인 수정반영
도서 책장 페이지 카테고리, 검색 바 컴포넌트 추가

## 🐢 변경사항

* 도서관 카드 컴포넌트 스타일 변경
* 도서관 책장 검색바, 카테고리 바텀시트 추가
* select_options 상수 추가

## 📷 스크린샷

<table>
  <tr>
    <td><img width="323" height="672" alt="image" src="https://github.com/user-attachments/assets/ea336b1a-a58a-45bc-b837-d9bb9df58f4a" /></td>
    <td><img width="323" height="668" alt="image" src="https://github.com/user-attachments/assets/347eeda1-13d6-448b-9c98-665dd20d37b1" /></td>
  </tr>
</table>

