### PR TITLE
회원가입,로그인,로그아웃 API 연결

### DIFF
--- a/src/pages/login/login-page.tsx
+++ b/src/pages/login/login-page.tsx
@@ -8,36 +8,32 @@ import { authMutations } from '@apis/auth/auth-mutations';
 import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { ROUTES } from '@routes/routes-config';
+import { loginSchema, emailSchema } from '@/shared/types/auth/signup';
 
 export default function LoginPage() {
   const [email, setEmail] = useState('');
-  const [emailError, setEmailError] = useState<'format' | 'login' | null>(null);
+  const [emailError, setEmailError] = useState('');
   const [pw, setPw] = useState('');
-  const [pwError, setPwError] = useState(false);
+  const [pwError, setPwError] = useState('');
+  const [loginError, setLoginError] = useState('');
   const navigate = useNavigate();
 
   const loginMutation = useMutation(authMutations.POST_LOGIN());
 
-  const validateEmail = (value: string) => {
-    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
-  };
-
-  const getEmailErrorMessage = () => {
-    if (emailError === 'format') return '이메일 형식을 확인해주세요.';
-    if (emailError === 'login') return '이메일 또는 비밀번호를 확인해주세요.';
-    return '';
-  };
-
   const submit = () => {
-    const isEmailValid = validateEmail(email);
-    const isPwValid = pw.length > 0;
+    const result = loginSchema.safeParse({ email, password: pw });
 
-    setEmailError(isEmailValid ? null : 'format');
-    setPwError(!isPwValid);
-
-    if (!isEmailValid || !isPwValid) {
+    if (!result.success) {
+      const errors = result.error.flatten().fieldErrors;
+      setEmailError(errors.email?.[0] || '');
+      setPwError(errors.password?.[0] || '');
+      setLoginError('');
       return;
     }
+
+    setEmailError('');
+    setPwError('');
+    setLoginError('');
 
     loginMutation.mutate(
       {
@@ -47,13 +43,11 @@ export default function LoginPage() {
       {
         onSuccess: (data) => {
           localStorage.setItem('accessToken', data.accessToken);
-          localStorage.setItem('refreshToken', data.refreshToken);
           navigate(ROUTES.HOME);
         },
         onError: (error) => {
           console.error('로그인 실패:', error);
-          setEmailError('login');
-          setPwError(false);
+          setLoginError('이메일 또는 비밀번호를 확인해주세요.');
         },
       }
     );
@@ -72,19 +66,23 @@ export default function LoginPage() {
             value={email}
             onChange={(e) => {
               setEmail(e.currentTarget.value);
-              if (emailError) setEmailError(null);
+              if (emailError) setEmailError('');
+              if (loginError) setLoginError('');
             }}
             onBlur={() => {
-              if (email && !validateEmail(email)) {
-                setEmailError('format');
+              if (email) {
+                const result = emailSchema.shape.email.safeParse(email);
+                if (!result.success) {
+                  setEmailError(result.error?.message || '');
+                }
               }
             }}
             inputMode='email'
             autoCapitalize='none'
             autoCorrect='off'
             autoComplete='email'
-            isError={!!emailError}
-            validationMessage={getEmailErrorMessage()}
+            isError={!!emailError || !!loginError}
+            validationMessage={emailError || loginError}
           />
 
           <Input
@@ -95,11 +93,12 @@ export default function LoginPage() {
             passwordToggle
             onChange={(e) => {
               setPw(e.currentTarget.value);
-              if (pwError) setPwError(false);
+              if (pwError) setPwError('');
+              if (loginError) setLoginError('');
             }}
             autoComplete='current-password'
-            isError={pwError}
-            validationMessage={pwError ? '비밀번호를 입력해주세요.' : ''}
+            isError={!!pwError}
+            validationMessage={pwError}
           />
         </div>
 

--- a/src/pages/login/login-page.tsx
+++ b/src/pages/login/login-page.tsx
@@ -4,10 +4,60 @@ import Button from '@components/button/button';
 import ButtonFrame from '@components/button/button-frame';
 import KakaoLoginButton from '@pages/login/components/kakao-login-button';
 import GoogleLoginButton from '@pages/login/components/google-login-button';
+import { authMutations } from '@apis/auth/auth-mutations';
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { ROUTES } from '@routes/routes-config';
 
 export default function LoginPage() {
   const [email, setEmail] = useState('');
+  const [emailError, setEmailError] = useState<'format' | 'login' | null>(null);
   const [pw, setPw] = useState('');
+  const [pwError, setPwError] = useState(false);
+  const navigate = useNavigate();
+
+  const loginMutation = useMutation(authMutations.POST_LOGIN());
+
+  const validateEmail = (value: string) => {
+    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+  };
+
+  const getEmailErrorMessage = () => {
+    if (emailError === 'format') return '이메일 형식을 확인해주세요.';
+    if (emailError === 'login') return '이메일 또는 비밀번호를 확인해주세요.';
+    return '';
+  };
+
+  const submit = () => {
+    const isEmailValid = validateEmail(email);
+    const isPwValid = pw.length > 0;
+
+    setEmailError(isEmailValid ? null : 'format');
+    setPwError(!isPwValid);
+
+    if (!isEmailValid || !isPwValid) {
+      return;
+    }
+
+    loginMutation.mutate(
+      {
+        email,
+        password: pw,
+      },
+      {
+        onSuccess: (data) => {
+          localStorage.setItem('accessToken', data.accessToken);
+          localStorage.setItem('refreshToken', data.refreshToken);
+          navigate(ROUTES.HOME);
+        },
+        onError: (error) => {
+          console.error('로그인 실패:', error);
+          setEmailError('login');
+          setPwError(false);
+        },
+      }
+    );
+  };
 
   return (
     <div className='flex-col-between bg-gray-white min-h-dvh text-gray-900'>
@@ -20,11 +70,21 @@ export default function LoginPage() {
             label='이메일'
             placeholder='이메일을 입력해 주세요.'
             value={email}
-            onChange={(e) => setEmail(e.currentTarget.value)}
+            onChange={(e) => {
+              setEmail(e.currentTarget.value);
+              if (emailError) setEmailError(null);
+            }}
+            onBlur={() => {
+              if (email && !validateEmail(email)) {
+                setEmailError('format');
+              }
+            }}
             inputMode='email'
             autoCapitalize='none'
             autoCorrect='off'
             autoComplete='email'
+            isError={!!emailError}
+            validationMessage={getEmailErrorMessage()}
           />
 
           <Input
@@ -33,8 +93,13 @@ export default function LoginPage() {
             placeholder='비밀번호를 입력해 주세요.'
             value={pw}
             passwordToggle
-            onChange={(e) => setPw(e.currentTarget.value)}
+            onChange={(e) => {
+              setPw(e.currentTarget.value);
+              if (pwError) setPwError(false);
+            }}
             autoComplete='current-password'
+            isError={pwError}
+            validationMessage={pwError ? '비밀번호를 입력해주세요.' : ''}
           />
         </div>
 
@@ -59,8 +124,8 @@ export default function LoginPage() {
       </div>
 
       <ButtonFrame>
-        <Button fullWidth className='py-[1.2rem]'>
-          로그인
+        <Button fullWidth className='py-[1.2rem]' onClick={submit} disabled={loginMutation.isPending}>
+          {loginMutation.isPending ? '로그인 중...' : '로그인'}
         </Button>
       </ButtonFrame>
     </div>

--- a/src/pages/setting/setting-page.tsx
+++ b/src/pages/setting/setting-page.tsx
@@ -1,7 +1,15 @@
+import { isAuthenticated } from '@/shared/utils/auth';
+import { memberQueries } from '@apis/member/member-queries';
 import Icon from '@components/icon';
+import { useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
 
 export default function SettingPage() {
+  const { data: memberData } = useQuery({
+    ...memberQueries.GET_ME(),
+    enabled: isAuthenticated(),
+  });
+
   return (
     <div className='bg-gray-50 text-gray-900'>
       <div className='mx-auto w-full flex-col gap-[1rem] pb-[3rem]'>
@@ -9,7 +17,7 @@ export default function SettingPage() {
           <div className='flex items-center gap-[1.2rem]'>
             <Icon name='cat-profile' size={6} className='text-gray-200' ariaHidden />
             <div className='min-w-0 flex-1'>
-              <p className='title5'>북북</p>
+              <p className='title5'>{memberData ? memberData.name : '북북'}</p>
               <button type='button' className='flex cursor-pointer items-center gap-[0.4rem] text-gray-500'>
                 <span className='caption3'>내 정보 수정</span>
                 <Icon name='dropdown' rotate={270} size={1.6} className='text-gray-400' ariaHidden />

--- a/src/pages/signup/components/step-password.tsx
+++ b/src/pages/signup/components/step-password.tsx
@@ -4,44 +4,52 @@ import Button from '@components/button/button';
 import ButtonFrame from '@components/button/button-frame';
 import { useFunnel } from '@libs/funnel';
 import { useSignupData } from '@pages/signup/signup-data-context';
-import { submitSignup } from '@apis/auth';
+import { useMutation } from '@tanstack/react-query';
+import { authMutations, type SignupApiRequest } from '@apis/auth/auth-mutations';
 
 function isStrong(pw: string) {
   return pw.length >= 8 && /[A-Za-z]/u.test(pw) && /\d/u.test(pw);
 }
 
 export default function StepPassword() {
-  const { data, setData } = useSignupData();
+  const { data, setData, reset } = useSignupData();
   const { goNext } = useFunnel();
 
   const [touched, setTouched] = useState<{ pw: boolean; pw2: boolean }>({ pw: false, pw2: false });
-  const [submitting, setSubmitting] = useState(false);
+
+  const signupMutation = useMutation(authMutations.POST_SIGNUP());
 
   const pwValid = isStrong(data.password);
   const match = data.password.length > 0 && data.password === data.passwordConfirm;
-  const canSubmit = pwValid && match && !submitting;
+  const canSubmit = pwValid && match && !signupMutation.isPending;
 
-  const onSubmit = async () => {
+  const onSubmit = () => {
     if (!canSubmit) {
       setTouched({ pw: true, pw2: true });
       return;
     }
-    setSubmitting(true);
-    try {
-      await submitSignup({
-        name: data.name,
-        nickname: data.nickname,
-        email: data.email,
-        zip: data.zip,
-        addr1: data.addr1,
-        addr2: data.addr2,
-        phone: data.phone,
-        password: data.password,
-      });
-      goNext();
-    } finally {
-      setSubmitting(false);
-    }
+
+    const address = [data.zip, data.addr1, data.addr2].filter(Boolean).join(' ');
+
+    const payload: SignupApiRequest = {
+      email: data.email,
+      password: data.password,
+      name: data.name,
+      nickname: data.nickname,
+      address: address,
+      phone: data.phone,
+    };
+
+    signupMutation.mutate(payload, {
+      onSuccess: () => {
+        reset(); // localStorage 정리
+        goNext();
+      },
+      onError: (error) => {
+        console.error('회원가입 실패:', error);
+        // TODO: 에러 메시지 표시 (Toast 등)
+      },
+    });
   };
 
   return (
@@ -78,9 +86,13 @@ export default function StepPassword() {
 
       <ButtonFrame>
         <Button fullWidth className='py-[1.2rem]' onClick={onSubmit} disabled={!canSubmit}>
-          가입하기
+          {signupMutation.isPending ? '가입 중...' : '가입하기'}
         </Button>
       </ButtonFrame>
+
+      {signupMutation.isError && (
+        <div className='px-[2rem] pb-[1rem] text-center text-red-500'>회원가입에 실패했습니다. 다시 시도해주세요.</div>
+      )}
     </div>
   );
 }

--- a/src/shared/apis/auth/auth-mutations.ts
+++ b/src/shared/apis/auth/auth-mutations.ts
@@ -1,0 +1,22 @@
+import { post } from '@apis/base/client';
+import { END_POINT } from '@constants/end-point';
+import { mutationKeys } from '@constants/query-keys';
+import { mutationOptions } from '@tanstack/react-query';
+
+export interface ILoginParams {
+  email: string;
+  password: string;
+}
+
+export interface ILoginResponse {
+  accessToken: string;
+  refreshToken: string;
+}
+
+export const authMutations = {
+  POST_LOGIN: () =>
+    mutationOptions<ILoginResponse, Error, ILoginParams>({
+      mutationKey: mutationKeys.auth.login,
+      mutationFn: (data) => post<ILoginResponse>(END_POINT.AUTH_LOGIN, data),
+    }),
+};

--- a/src/shared/apis/auth/auth-mutations.ts
+++ b/src/shared/apis/auth/auth-mutations.ts
@@ -13,10 +13,29 @@ export interface ILoginResponse {
   refreshToken: string;
 }
 
+export interface SignupApiRequest {
+  email: string;
+  password: string;
+  name: string;
+  nickname: string;
+  address: string;
+  phone: string;
+  profileImage?: string;
+}
+
+export interface SignupApiResponse {
+  data: boolean;
+}
+
 export const authMutations = {
   POST_LOGIN: () =>
     mutationOptions<ILoginResponse, Error, ILoginParams>({
       mutationKey: mutationKeys.auth.login,
       mutationFn: (data) => post<ILoginResponse>(END_POINT.AUTH_LOGIN, data),
+    }),
+  POST_SIGNUP: () =>
+    mutationOptions<SignupApiResponse, Error, SignupApiRequest>({
+      mutationKey: mutationKeys.auth.signup,
+      mutationFn: (data) => post<SignupApiResponse>(END_POINT.AUTH_SIGNUP, data),
     }),
 };

--- a/src/shared/apis/auth/auth-mutations.ts
+++ b/src/shared/apis/auth/auth-mutations.ts
@@ -10,7 +10,6 @@ export interface ILoginParams {
 
 export interface ILoginResponse {
   accessToken: string;
-  refreshToken: string;
 }
 
 export interface SignupApiRequest {
@@ -32,6 +31,11 @@ export const authMutations = {
     mutationOptions<ILoginResponse, Error, ILoginParams>({
       mutationKey: mutationKeys.auth.login,
       mutationFn: (data) => post<ILoginResponse>(END_POINT.AUTH_LOGIN, data),
+    }),
+  POST_LOGOUT: () =>
+    mutationOptions<void, Error, void>({
+      mutationKey: mutationKeys.auth.logout,
+      mutationFn: () => post<void>(END_POINT.AUTH_LOGOUT, {}),
     }),
   POST_SIGNUP: () =>
     mutationOptions<SignupApiResponse, Error, SignupApiRequest>({

--- a/src/shared/constants/end-point.ts
+++ b/src/shared/constants/end-point.ts
@@ -6,6 +6,7 @@ export const END_POINT = {
   REVIEW_RATING_BY_ID: (id: string) => `/review/rating/${id}`,
 
   // 인증 API
+  AUTH_LOGIN: '/auth/login',
   TOKEN_REISSUE: '/token/reissue',
 
   // 포인트 API

--- a/src/shared/constants/end-point.ts
+++ b/src/shared/constants/end-point.ts
@@ -7,6 +7,7 @@ export const END_POINT = {
 
   // 인증 API
   AUTH_LOGIN: '/auth/login',
+  AUTH_SIGNUP: '/member/signup',
   TOKEN_REISSUE: '/token/reissue',
 
   // 포인트 API

--- a/src/shared/constants/end-point.ts
+++ b/src/shared/constants/end-point.ts
@@ -7,6 +7,7 @@ export const END_POINT = {
 
   // 인증 API
   AUTH_LOGIN: '/auth/login',
+  AUTH_LOGOUT: '/auth/logout',
   AUTH_SIGNUP: '/member/signup',
   TOKEN_REISSUE: '/token/reissue',
 

--- a/src/shared/constants/query-keys.ts
+++ b/src/shared/constants/query-keys.ts
@@ -33,6 +33,7 @@ export const queryKeys = {
 export const mutationKeys = {
   auth: {
     login: ['auth', 'login'] as const,
+    signup: ['auth', 'signup'] as const,
   },
   library: {
     create: ['library', 'create'] as const,

--- a/src/shared/constants/query-keys.ts
+++ b/src/shared/constants/query-keys.ts
@@ -31,6 +31,9 @@ export const queryKeys = {
 } as const;
 
 export const mutationKeys = {
+  auth: {
+    login: ['auth', 'login'] as const,
+  },
   library: {
     create: ['library', 'create'] as const,
     update: ['library', 'update'] as const,

--- a/src/shared/constants/query-keys.ts
+++ b/src/shared/constants/query-keys.ts
@@ -33,6 +33,7 @@ export const queryKeys = {
 export const mutationKeys = {
   auth: {
     login: ['auth', 'login'] as const,
+    logout: ['auth', 'logout'] as const,
     signup: ['auth', 'signup'] as const,
   },
   library: {

--- a/src/shared/layouts/header.tsx
+++ b/src/shared/layouts/header.tsx
@@ -4,9 +4,12 @@ import Icon from '@components/icon';
 import SearchBar from '@components/search-bar';
 import { ROUTES } from '@routes/routes-config';
 import { useMemo } from 'react';
+import { modal } from '@libs/modal';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { authMutations } from '@apis/auth/auth-mutations';
 
 type LeftKind = 'none' | 'back' | 'logo' | 'close';
-type ActionId = 'search' | 'cart' | 'share' | 'kebab' | 'bell' | 'close' | 'logout';
+export type ActionId = 'search' | 'cart' | 'share' | 'kebab' | 'bell' | 'close' | 'logout';
 
 type TextCTA = { kind: 'link'; label: string; to: string } | { kind: 'button'; label: string; onClick: () => void };
 
@@ -62,17 +65,49 @@ export default function Header({
 }: HeaderProps) {
   const nav = useNavigate();
   const { pathname } = useLocation();
+  const queryClient = useQueryClient();
   const isSetting = useMemo(() => isUnder(pathname, ROUTES.SETTING), [pathname]);
   const isBoard = useMemo(() => isUnder(pathname, ROUTES.BOARD), [pathname]);
   const NoShadow = isSetting || isBoard;
 
-  const handleAction = (id: ActionId) => {
+  const logoutMutation = useMutation({
+    ...authMutations.POST_LOGOUT(),
+    onSuccess: () => {
+      // 로그아웃 시 모든 캐시 초기화
+      queryClient.clear();
+    },
+  });
+
+  const handleAction = async (id: ActionId) => {
     if (id === 'bell') {
       nav(ROUTES.NOTIFICATION);
       return;
     }
     if (id === 'close' && !onAction) {
       nav(-1);
+      return;
+    }
+    if (id === 'logout' && !onAction) {
+      const result = await modal.confirm({
+        title: '로그아웃 하시겠습니까?',
+        confirmText: '로그아웃',
+        cancelText: '취소',
+      });
+
+      if (result.ok) {
+        try {
+          await logoutMutation.mutateAsync();
+          localStorage.removeItem('accessToken');
+          localStorage.removeItem('refreshToken');
+          nav(ROUTES.LOGIN);
+        } catch (error) {
+          console.error('로그아웃 실패:', error);
+          // 실패해도 로컬 토큰 제거 및 로그인 페이지 이동
+          localStorage.removeItem('accessToken');
+          localStorage.removeItem('refreshToken');
+          nav(ROUTES.LOGIN);
+        }
+      }
       return;
     }
     onAction?.(id);

--- a/src/shared/types/auth/signup.ts
+++ b/src/shared/types/auth/signup.ts
@@ -27,13 +27,15 @@ export const phoneSchema = z.object({
     .regex(/^0\d{1,2}-\d{3,4}-\d{4}$/, '예: 010-1234-5678'),
 });
 
+const passwordValidation = z
+  .string()
+  .min(8, '8자 이상 입력해 주세요.')
+  .regex(/[A-Za-z]/, '영문을 포함해 주세요.')
+  .regex(/\d/, '숫자를 포함해 주세요.');
+
 export const passwordSchema = z
   .object({
-    password: z
-      .string()
-      .min(8, '8자 이상 입력해 주세요.')
-      .regex(/[A-Za-z]/, '영문을 포함해 주세요.')
-      .regex(/\d/, '숫자를 포함해 주세요.'),
+    password: passwordValidation,
     passwordConfirm: z.string().min(1, '비밀번호 확인을 입력해 주세요.'),
   })
   .refine((v) => v.password === v.passwordConfirm, {
@@ -41,10 +43,11 @@ export const passwordSchema = z
     message: '비밀번호가 일치하지 않습니다.',
   });
 
-export const loginSchema = z.object({
-  email: z.string().trim().email('이메일 형식을 확인해주세요.'),
-  password: z.string().min(1, '비밀번호를 입력해주세요.'),
-});
+export const loginSchema = emailSchema.and(
+  z.object({
+    password: passwordValidation,
+  })
+);
 
 export const signupSchema = nameNickSchema.and(emailSchema).and(addressSchema).and(phoneSchema).and(passwordSchema);
 

--- a/src/shared/types/auth/signup.ts
+++ b/src/shared/types/auth/signup.ts
@@ -41,6 +41,11 @@ export const passwordSchema = z
     message: '비밀번호가 일치하지 않습니다.',
   });
 
+export const loginSchema = z.object({
+  email: z.string().trim().email('이메일 형식을 확인해주세요.'),
+  password: z.string().min(1, '비밀번호를 입력해주세요.'),
+});
+
 export const signupSchema = nameNickSchema.and(emailSchema).and(addressSchema).and(phoneSchema).and(passwordSchema);
 
 export type NameNick = z.infer<typeof nameNickSchema>;
@@ -49,4 +54,5 @@ export type EmailCode = z.infer<typeof emailCodeSchema>;
 export type Address = z.infer<typeof addressSchema>;
 export type Phone = z.infer<typeof phoneSchema>;
 export type Passwords = z.infer<typeof passwordSchema>;
+export type LoginPayload = z.infer<typeof loginSchema>;
 export type SignupPayload = z.infer<typeof signupSchema>;


### PR DESCRIPTION
## 📝작업 내용

로그인,회원가입,로그아웃 API 연결과 기능을 구현했습니다.
정의해주신 Zod 스키마 파일(signup.tsx) 수정해서 활용했습니다.

## 🐢 변경사항

```jsx
const passwordValidation = z
  .string()
  .min(8, '8자 이상 입력해 주세요.')
  .regex(/[A-Za-z]/, '영문을 포함해 주세요.')
  .regex(/\d/, '숫자를 포함해 주세요.');

export const passwordSchema = z
  .object({
    password: passwordValidation,
    passwordConfirm: z.string().min(1, '비밀번호 확인을 입력해 주세요.'),
  })
  .refine((v) => v.password === v.passwordConfirm, {
    path: ['passwordConfirm'],
    message: '비밀번호가 일치하지 않습니다.',
  });
```
1. loginSchema에서 비밀번호 유효성 재사용 위해 passwordSchema에서 password 속성을 분리했습니다.
```jsx
    if (id === 'bell') {
      nav(ROUTES.NOTIFICATION);
      return;
    }
    if (id === 'close' && !onAction) {
      nav(-1);
      return;
    }
    if (id === 'logout' && !onAction) {
      const result = await modal.confirm({
        title: '로그아웃 하시겠습니까?',
        confirmText: '로그아웃',
        cancelText: '취소',
      });

      if (result.ok) {
        try {
          await logoutMutation.mutateAsync();
          localStorage.removeItem('accessToken');
          nav(ROUTES.LOGIN);
        } catch (error) {
          console.error('로그아웃 실패:', error);
          // 실패해도 로컬 토큰 제거 및 로그인 페이지 이동
          localStorage.removeItem('accessToken');
          nav(ROUTES.LOGIN);
        }
      }
      return;
    }
    onAction?.(id);
  };
```
2. header.tsx 내부 handleAction함수에 logout 로직 추가했습니다. 추후 필요하다면 내부 로직은 따로 분리하겠습니다.
3. 로그인, 로그아웃, 회원가입 API 연결 및 mutation 연결했습니다.



