### PR TITLE
토큰 재발급 로직 추가

### DIFF
--- a/src/pages/home/home-page.tsx
+++ b/src/pages/home/home-page.tsx
@@ -1,5 +1,6 @@
 import 'keen-slider/keen-slider.min.css';
 import { useNavigate } from 'react-router-dom';
+import { useEffect } from 'react';
 import { useHomeData } from '@pages/home/hooks/useHomeData';
 import HomeBanner from '@pages/home/components/banner/home-banner';
 import HomeReservation from '@pages/home/components/section/home-reservation';
@@ -19,6 +20,13 @@ import { isAuthenticated } from '@/shared/utils/auth';
 
 export default function HomePage() {
   const navigate = useNavigate();
+
+  // 비로그인 상태면 온보딩 페이지로 리다이렉트
+  useEffect(() => {
+    if (!isAuthenticated()) {
+      navigate(ROUTES.ONBOARDING, { replace: true });
+    }
+  }, [navigate]);
 
   const handleLoanViewAll = () => {
     navigate(ROUTES.RENTAL);

--- a/src/pages/login/login-page.tsx
+++ b/src/pages/login/login-page.tsx
@@ -9,6 +9,7 @@ import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { ROUTES } from '@routes/routes-config';
 import { loginSchema, emailSchema } from '@/shared/types/auth/signup';
+import { setAccessToken } from '@/shared/utils/auth';
 
 export default function LoginPage() {
   const [email, setEmail] = useState('');
@@ -42,7 +43,7 @@ export default function LoginPage() {
       },
       {
         onSuccess: (data) => {
-          localStorage.setItem('accessToken', data.accessToken);
+          setAccessToken(data.accessToken);
           navigate(ROUTES.HOME);
         },
         onError: (error) => {

--- a/src/shared/apis/auth/auth-mutations.ts
+++ b/src/shared/apis/auth/auth-mutations.ts
@@ -26,6 +26,10 @@ export interface SignupApiResponse {
   data: boolean;
 }
 
+export interface ITokenReissueResponse {
+  accessToken: string;
+}
+
 export const authMutations = {
   POST_LOGIN: () =>
     mutationOptions<ILoginResponse, Error, ILoginParams>({
@@ -41,5 +45,10 @@ export const authMutations = {
     mutationOptions<SignupApiResponse, Error, SignupApiRequest>({
       mutationKey: mutationKeys.auth.signup,
       mutationFn: (data) => post<SignupApiResponse>(END_POINT.AUTH_SIGNUP, data),
+    }),
+  POST_TOKEN_REISSUE: () =>
+    mutationOptions<ITokenReissueResponse, Error, void>({
+      mutationKey: mutationKeys.auth.reissue,
+      mutationFn: () => post<ITokenReissueResponse>(END_POINT.TOKEN_REISSUE, {}),
     }),
 };

--- a/src/shared/apis/base/client.ts
+++ b/src/shared/apis/base/client.ts
@@ -1,5 +1,7 @@
-import axios, { type AxiosError } from 'axios';
+import axios, { type AxiosError, type InternalAxiosRequestConfig } from 'axios';
 import { ERROR_CODES, ERROR_MESSAGES, HTTP_STATUS } from '@constants/http';
+import { END_POINT } from '@constants/end-point';
+import { getAccessToken, removeAccessToken, setAccessToken } from '@/shared/utils/auth';
 
 export interface ApiResponse<T = unknown> {
   success: boolean;
@@ -60,6 +62,7 @@ const createHttpClient = (baseURL: string) => {
   const instance = axios.create({
     baseURL,
     timeout: 10000,
+    withCredentials: true,
     headers: {
       'Content-Type': 'application/json',
     },
@@ -67,7 +70,7 @@ const createHttpClient = (baseURL: string) => {
 
   instance.interceptors.request.use(
     (config) => {
-      const token = localStorage.getItem('accessToken');
+      const token = getAccessToken();
       if (token) {
         config.headers.Authorization = `Bearer ${token}`;
       }
@@ -88,10 +91,25 @@ const createHttpClient = (baseURL: string) => {
       return response;
     },
     async (error: AxiosError<ApiResponse>) => {
+      const originalRequest = error.config as InternalAxiosRequestConfig & { _retry?: boolean };
       const status = error.response?.status;
 
-      if (status === HTTP_STATUS.UNAUTHORIZED) {
-        // 401 오류처리
+      if (status === HTTP_STATUS.UNAUTHORIZED && !originalRequest._retry) {
+        originalRequest._retry = true;
+
+        try {
+          const response = await instance.post<ApiResponse<string>>(END_POINT.TOKEN_REISSUE, {});
+          const newAccessToken = response.data.data;
+
+          if (newAccessToken) {
+            setAccessToken(newAccessToken);
+            originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+            return instance(originalRequest);
+          }
+        } catch (refreshError) {
+          removeAccessToken();
+          return Promise.reject(refreshError);
+        }
       }
 
       const apiError = handleError(error);

--- a/src/shared/constants/query-keys.ts
+++ b/src/shared/constants/query-keys.ts
@@ -35,6 +35,7 @@ export const mutationKeys = {
     login: ['auth', 'login'] as const,
     logout: ['auth', 'logout'] as const,
     signup: ['auth', 'signup'] as const,
+    reissue: ['auth', 'reissue'] as const,
   },
   library: {
     create: ['library', 'create'] as const,

--- a/src/shared/layouts/header.tsx
+++ b/src/shared/layouts/header.tsx
@@ -7,6 +7,7 @@ import { useMemo } from 'react';
 import { modal } from '@libs/modal';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { authMutations } from '@apis/auth/auth-mutations';
+import { removeAccessToken } from '../utils/auth';
 
 type LeftKind = 'none' | 'back' | 'logo' | 'close';
 export type ActionId = 'search' | 'cart' | 'share' | 'kebab' | 'bell' | 'close' | 'logout';
@@ -97,14 +98,11 @@ export default function Header({
       if (result.ok) {
         try {
           await logoutMutation.mutateAsync();
-          localStorage.removeItem('accessToken');
-          localStorage.removeItem('refreshToken');
+          removeAccessToken();
           nav(ROUTES.LOGIN);
         } catch (error) {
           console.error('로그아웃 실패:', error);
-          // 실패해도 로컬 토큰 제거 및 로그인 페이지 이동
-          localStorage.removeItem('accessToken');
-          localStorage.removeItem('refreshToken');
+          removeAccessToken();
           nav(ROUTES.LOGIN);
         }
       }


### PR DESCRIPTION
● ## 📝 작업 내용

  httpOnly 쿠키 기반 RefreshToken을 사용한 자동 토큰 갱신 로직과 인증 기반 초기 라우팅을 구현했습니다.

  ## 🐢 변경사항

  ### 1. 자동 토큰 갱신 시스템 구현
  - `/api/token/reissue` API 추가 및 HTTP Client Response Interceptor에서 401 에러 감지 시 자동 토큰 재발급
  - refreshToken은 httpOnly 쿠키로 관리되어 브라우저가 자동 전송 (`withCredentials: true`)
  - 비로그인 시 홈 페이지에서 온보딩 페이지로 리다이렉트