### PR TITLE
게시판 커뮤니티 기능 구현

### DIFF
--- a/src/pages/board/board-create-page.tsx
+++ b/src/pages/board/board-create-page.tsx
@@ -3,48 +3,86 @@ import ButtonFrame from '@components/button/button-frame';
 import Input from '@components/input/input';
 import PillTab from '@components/tab/pill-tab';
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useMutation } from '@tanstack/react-query';
+import { boardMutations } from '@apis/board/board-mutations';
+import type { BoardCategory } from '@apis/board/board-queries';
 import type { TabItem } from './board-page';
+import { toast } from '@libs/toast';
 
 export const CATEGORIES: TabItem[] = [
-  { key: 'RECOMMEND', label: '책 추천' },
   { key: 'GENERAL', label: '일상' },
+  { key: 'RECOMMEND', label: '책 추천' },
   { key: 'GATHER', label: '모임 모집' },
 ];
 
 export default function BoardCreatePage() {
+  const navigate = useNavigate();
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
-  const [category, setCategory] = useState<string>('all');
-  console.log(title, content);
+  const [category, setCategory] = useState<string>('GENERAL');
+
+  const createMutation = useMutation(boardMutations.POST_BOARD());
+
+  const handleSubmit = async () => {
+    if (!title.trim()) {
+      toast.error('제목을 입력해주세요');
+      return;
+    }
+    if (!content.trim()) {
+      toast.error('내용을 입력해주세요');
+      return;
+    }
+
+    try {
+      const boardId = await createMutation.mutateAsync({
+        title: title.trim(),
+        content: content.trim(),
+        category: category as BoardCategory,
+      });
+      toast.success('게시글이 등록되었습니다');
+      navigate(`/board/${boardId}`);
+    } catch (error) {
+      toast.error('게시글 등록에 실패했습니다');
+      console.error(error);
+    }
+  };
 
   return (
-    <div className='flex-col gap-[2.5rem] p-[1.5rem]'>
-      <PillTab items={CATEGORIES} value={category} onChange={setCategory} label='카테고리' className='px-0 py-0' />
+    <main>
+      <div className='flex-col gap-[2.5rem] p-[1.5rem]'>
+        <PillTab items={CATEGORIES} value={category} onChange={setCategory} label='카테고리' className='px-0 py-0' />
 
-      <Input
-        id='board-title'
-        label='제목'
-        placeholder='제목을 입력해 주세요.'
-        onChange={(e) => setTitle(e.currentTarget.value)}
-      />
+        <Input
+          id='board-title'
+          label='제목'
+          placeholder='제목을 입력해 주세요.'
+          onChange={(e) => setTitle(e.currentTarget.value)}
+        />
 
-      <Input
-        id='board-content'
-        label='내용'
-        placeholder='내용을 입력해주세요'
-        multiline
-        maxLength={1000}
-        hasLength
-        value={desc}
-        onChange={(e) => setContent(e.currentTarget.value)}
-        length={desc.length}
-      />
-
+        <Input
+          id='board-content'
+          label='내용'
+          placeholder='내용을 입력해주세요'
+          multiline
+          maxLength={1000}
+          hasLength
+          value={content}
+          onChange={(e) => setContent(e.currentTarget.value)}
+          length={content.length}
+        />
+      </div>
       <ButtonFrame>
-        <Button fullWidth roundStyle='rounded-[12px]' className='py-[1.2rem]'>
+        <Button
+          fullWidth
+          roundStyle='rounded-[12px]'
+          className='py-[1.2rem]'
+          onClick={handleSubmit}
+          loading={createMutation.isPending}
+        >
           등록하기
         </Button>
       </ButtonFrame>
-    </div>
+    </main>
   );
 }

--- a/src/pages/board/board-create-page.tsx
+++ b/src/pages/board/board-create-page.tsx
@@ -2,10 +2,11 @@ import Button from '@components/button/button';
 import ButtonFrame from '@components/button/button-frame';
 import Input from '@components/input/input';
 import PillTab from '@components/tab/pill-tab';
-import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { useMutation } from '@tanstack/react-query';
+import { useState, useEffect } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { boardMutations } from '@apis/board/board-mutations';
+import { boardQueries } from '@apis/board/board-queries';
 import type { BoardCategory } from '@apis/board/board-queries';
 import type { TabItem } from './board-page';
 import { toast } from '@libs/toast';
@@ -17,12 +18,30 @@ export const CATEGORIES: TabItem[] = [
 ];
 
 export default function BoardCreatePage() {
+  const [searchParams] = useSearchParams();
   const navigate = useNavigate();
+  const boardId = searchParams.get('id');
+  const isEditMode = !!boardId;
+
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const [category, setCategory] = useState<string>('GENERAL');
 
-  const createMutation = useMutation(boardMutations.POST_BOARD());
+  const { data: boardDetail } = useQuery({
+    ...boardQueries.GET_BOARD_DETAIL(boardId || ''),
+    enabled: isEditMode,
+  });
+
+  const { mutate: createBoard } = useMutation(boardMutations.POST_BOARD());
+  const { mutate: updateBoard } = useMutation(boardMutations.PUT_BOARD());
+
+  useEffect(() => {
+    if (isEditMode && boardDetail) {
+      setTitle(boardDetail.title);
+      setContent(boardDetail.content);
+      setCategory(boardDetail.category);
+    }
+  }, [isEditMode, boardDetail]);
 
   const handleSubmit = async () => {
     if (!title.trim()) {
@@ -34,29 +53,62 @@ export default function BoardCreatePage() {
       return;
     }
 
-    try {
-      const boardId = await createMutation.mutateAsync({
-        title: title.trim(),
-        content: content.trim(),
-        category: category as BoardCategory,
-      });
-      toast.success('게시글이 등록되었습니다');
-      navigate(`/board/${boardId}`);
-    } catch (error) {
-      toast.error('게시글 등록에 실패했습니다');
-      console.error(error);
+    if (isEditMode && boardId) {
+      // 수정 요청
+      updateBoard(
+        {
+          boardId,
+          title: title.trim(),
+          content: content.trim(),
+        },
+        {
+          onSuccess: () => {
+            toast.success('게시글이 수정되었습니다');
+            navigate(`/board/${boardId}`);
+          },
+          onError: () => {
+            toast.error('게시글 수정에 실패했습니다');
+          },
+        }
+      );
+    } else {
+      // 생성 요청
+      createBoard(
+        {
+          title: title.trim(),
+          content: content.trim(),
+          category: category as BoardCategory,
+        },
+        {
+          onSuccess: (newBoardId) => {
+            toast.success('게시글이 등록되었습니다');
+            navigate(`/board/${newBoardId}`);
+          },
+          onError: () => {
+            toast.error('게시글 등록에 실패했습니다');
+          },
+        }
+      );
     }
   };
 
   return (
     <main>
       <div className='flex-col gap-[2.5rem] p-[1.5rem]'>
-        <PillTab items={CATEGORIES} value={category} onChange={setCategory} label='카테고리' className='px-0 py-0' />
+        <PillTab
+          items={CATEGORIES}
+          value={category}
+          onChange={setCategory}
+          label='카테고리'
+          className='px-0 py-0'
+          disabled={isEditMode}
+        />
 
         <Input
           id='board-title'
           label='제목'
           placeholder='제목을 입력해 주세요.'
+          value={title}
           onChange={(e) => setTitle(e.currentTarget.value)}
         />
 
@@ -73,14 +125,8 @@ export default function BoardCreatePage() {
         />
       </div>
       <ButtonFrame>
-        <Button
-          fullWidth
-          roundStyle='rounded-[12px]'
-          className='py-[1.2rem]'
-          onClick={handleSubmit}
-          loading={createMutation.isPending}
-        >
-          등록하기
+        <Button fullWidth roundStyle='rounded-[12px]' className='py-[1.2rem]' onClick={handleSubmit}>
+          {isEditMode ? '수정하기' : '등록하기'}
         </Button>
       </ButtonFrame>
     </main>

--- a/src/pages/board/board-create-page.tsx
+++ b/src/pages/board/board-create-page.tsx
@@ -1,0 +1,50 @@
+import Button from '@components/button/button';
+import ButtonFrame from '@components/button/button-frame';
+import Input from '@components/input/input';
+import PillTab from '@components/tab/pill-tab';
+import { useState } from 'react';
+import type { TabItem } from './board-page';
+
+export const CATEGORIES: TabItem[] = [
+  { key: 'RECOMMEND', label: '책 추천' },
+  { key: 'GENERAL', label: '일상' },
+  { key: 'GATHER', label: '모임 모집' },
+];
+
+export default function BoardCreatePage() {
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [category, setCategory] = useState<string>('all');
+  console.log(title, content);
+
+  return (
+    <div className='flex-col gap-[2.5rem] p-[1.5rem]'>
+      <PillTab items={CATEGORIES} value={category} onChange={setCategory} label='카테고리' className='px-0 py-0' />
+
+      <Input
+        id='board-title'
+        label='제목'
+        placeholder='제목을 입력해 주세요.'
+        onChange={(e) => setTitle(e.currentTarget.value)}
+      />
+
+      <Input
+        id='board-content'
+        label='내용'
+        placeholder='내용을 입력해주세요'
+        multiline
+        maxLength={1000}
+        hasLength
+        value={desc}
+        onChange={(e) => setContent(e.currentTarget.value)}
+        length={desc.length}
+      />
+
+      <ButtonFrame>
+        <Button fullWidth roundStyle='rounded-[12px]' className='py-[1.2rem]'>
+          등록하기
+        </Button>
+      </ButtonFrame>
+    </div>
+  );
+}

--- a/src/pages/board/board-detail-page.tsx
+++ b/src/pages/board/board-detail-page.tsx
@@ -33,7 +33,7 @@ export default function BoardDetailPage() {
       setIsManageBottomSheetOpen(false);
 
       if (option === 'modify') {
-        navigate(`/board/${id}/edit`);
+        navigate(`/board-create?id=${id}`);
       } else if (option === 'delete') {
         const confirmDelete = await modal.confirm({
           title: '정말 삭제하시겠습니까?',

--- a/src/pages/board/board-detail-page.tsx
+++ b/src/pages/board/board-detail-page.tsx
@@ -1,12 +1,19 @@
 import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
 import Icon from '@components/icon';
 import CommentBottomSheet from '@components/bottom-sheet/comment-bottom-sheet';
 import type { CommentItem } from '@components/bottom-sheet/types/comment';
+import { boardQueries } from '@apis/board/board-queries';
 
 export default function BoardDetailPage() {
+  const { id } = useParams<{ id: string }>();
   const [isCommentDrawerOpen, setIsCommentDrawerOpen] = useState(false);
 
-  // Mock data - 실제로는 API에서 가져올 데이터
+  console.log(id);
+
+  const { data: boardDetail, isLoading } = useQuery(boardQueries.GET_BOARD_DETAIL(id!));
+
   const comments: CommentItem[] = [
     {
       id: '550e8400-e29b-41d4-a716-446655440000',
@@ -65,29 +72,65 @@ export default function BoardDetailPage() {
     return true;
   };
 
+  // 날짜 포맷팅 (ISO -> YYYY.MM.DD)
+  const formatDate = (isoDate: string): string => {
+    const date = new Date(isoDate);
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}.${month}.${day}`;
+  };
+
+  if (isLoading) {
+    return (
+      <main className='flex-col gap-[1.5rem] px-[1.5rem] py-[2.5rem]'>
+        <div className='body5 py-[4rem] text-center text-gray-500'>로딩 중...</div>
+      </main>
+    );
+  }
+
+  if (!boardDetail) {
+    return (
+      <main className='flex-col gap-[1.5rem] px-[1.5rem] py-[2.5rem]'>
+        <div className='body5 py-[4rem] text-center text-gray-500'>게시글을 찾을 수 없습니다.</div>
+      </main>
+    );
+  }
+
   return (
     <main className='flex-col gap-[1.5rem] px-[1.5rem] py-[2.5rem]'>
       <header className='flex gap-[1rem]'>
-        <img className='h-[4rem] w-[4rem] rounded-full bg-gray-100'></img>
+        <div className='h-[4rem] w-[4rem] shrink-0 rounded-full bg-gray-100' />
         <div className='flex-col gap-[0.2rem]'>
-          <h1 className='caption1'>닉네임</h1>
-          <p className='caption5 rounded-[2px] bg-gray-100 px-[7px] text-gray-600'>2025.09.21</p>
+          <h1 className='caption1'>{boardDetail.writerName}</h1>
+          <p className='caption5 rounded-[2px] bg-gray-100 px-[7px] text-gray-600'>
+            {formatDate(boardDetail.createdAt)}
+            {boardDetail.isUpdated && ' (수정됨)'}
+          </p>
         </div>
       </header>
-      <section className='body4 min-h-[400px] border-b-1 border-gray-200 p-[1.5rem] text-gray-900'>
-        description....
+
+      <section className='flex-col gap-[1rem]'>
+        {/* <h2 className='title4 text-gray-900'>{boardDetail.title}</h2> */}
+        <div
+          className='body4 min-h-[400px] border-b-1 border-gray-200 py-[1.5rem] text-gray-900'
+          style={{ whiteSpace: 'pre-line' }}
+        >
+          {boardDetail.content}
+        </div>
       </section>
+
       {/* 댓글 섹션 */}
       <section>
         {!isCommentDrawerOpen && (
           <button type='button' onClick={handleCommentSectionClick} className='flex w-full cursor-pointer gap-[1rem]'>
             <span className='flex-items-center gap-[2px]'>
               <Icon name='comment' size={2.4} className='text-primary-900'></Icon>
-              <p className='caption1'>{comments.length}</p>
+              <p className='caption1'>{boardDetail.commentCount}</p>
             </span>
             <span className='flex-items-center gap-[2px]'>
               <Icon name='heart' size={2} className='text-system-error'></Icon>
-              <p className='caption1'>3</p>
+              <p className='caption1'>{boardDetail.likeCount}</p>
             </span>
           </button>
         )}

--- a/src/pages/board/board-detail-page.tsx
+++ b/src/pages/board/board-detail-page.tsx
@@ -21,7 +21,10 @@ export default function BoardDetailPage() {
   const [selectedManageOption, setSelectedManageOption] = useState<ReviewManage | null>(null);
 
   const { data: boardDetail, isLoading } = useQuery(boardQueries.GET_BOARD_DETAIL(id!));
+  const { data: isLiked = false } = useQuery(boardQueries.GET_BOARD_LIKE(id!));
   const { mutate: deleteBoard } = useMutation(boardMutations.DELETE_BOARD(id!));
+  const { mutate: addLike } = useMutation(boardMutations.POST_BOARD_LIKE(id!));
+  const { mutate: removeLike } = useMutation(boardMutations.DELETE_BOARD_LIKE(id!));
 
   const handleKebabClick = useCallback(() => {
     setIsManageBottomSheetOpen(true);
@@ -122,13 +125,34 @@ export default function BoardDetailPage() {
     setIsCommentDrawerOpen(false);
   };
 
-  const handleToggleLike = (kind: 'comment' | 'reply', id: string, parentId?: string) => {
-    // TODO: API 연동 - 좋아요 토글
-    console.log('Toggle like:', { kind, id, parentId });
+  const handleBoardLikeClick = useCallback(() => {
+    if (isLiked) {
+      removeLike(undefined, {
+        onSuccess: () => {
+          toast.success('게시글 좋아요를 취소했습니다');
+        },
+        onError: () => {
+          toast.error('좋아요 취소에 실패했습니다');
+        },
+      });
+    } else {
+      addLike(undefined, {
+        onSuccess: () => {
+          toast.success('게시글에 좋아요를 눌렀습니다!');
+        },
+        onError: () => {
+          toast.error('좋아요에 실패했습니다');
+        },
+      });
+    }
+  }, [isLiked, addLike, removeLike]);
+
+  const handleCommentToggleLike = (kind: 'comment' | 'reply', id: string, parentId?: string) => {
+    // TODO: 댓글 좋아요 API 연동
+    console.log('Toggle comment like:', { kind, id, parentId });
   };
 
   const handleSendComment = async (text: string) => {
-    // TODO: API 연동 - 댓글 작성
     console.log('Send comment:', text);
     return true;
   };
@@ -184,16 +208,20 @@ export default function BoardDetailPage() {
       {/* 댓글 섹션 */}
       <section>
         {!isCommentDrawerOpen && (
-          <button type='button' onClick={handleCommentSectionClick} className='flex w-full cursor-pointer gap-[1rem]'>
-            <span className='flex-items-center gap-[2px]'>
-              <Icon name='comment' size={2.4} className='text-primary-900'></Icon>
-              <p className='caption1'>{boardDetail.commentCount}</p>
-            </span>
-            <span className='flex-items-center gap-[2px]'>
-              <Icon name='heart' size={2} className='text-system-error'></Icon>
-              <p className='caption1'>{boardDetail.likeCount}</p>
-            </span>
-          </button>
+          <div className='flex w-full gap-[1rem]'>
+            <button type='button' onClick={handleCommentSectionClick} className='cursor-pointer'>
+              <span className='flex-items-center gap-[2px]'>
+                <Icon name='comment' size={2.4} className='text-primary-900'></Icon>
+                <p className='caption1'>{boardDetail.commentCount}</p>
+              </span>
+            </button>
+            <button type='button' onClick={handleBoardLikeClick} className='cursor-pointer'>
+              <span className='flex-items-center gap-[2px]'>
+                <Icon name={isLiked ? 'heart-fill' : 'heart'} size={2.4} className='text-system-error'></Icon>
+                <p className='caption1'>{boardDetail.likeCount}</p>
+              </span>
+            </button>
+          </div>
         )}
       </section>
 
@@ -201,7 +229,7 @@ export default function BoardDetailPage() {
         open={isCommentDrawerOpen}
         onClose={handleCloseDrawer}
         comments={comments}
-        onToggleLike={handleToggleLike}
+        onToggleLike={handleCommentToggleLike}
         onSend={handleSendComment}
       />
 

--- a/src/pages/board/board-detail-page.tsx
+++ b/src/pages/board/board-detail-page.tsx
@@ -1,0 +1,105 @@
+import { useState } from 'react';
+import Icon from '@components/icon';
+import CommentBottomSheet from '@components/bottom-sheet/comment-bottom-sheet';
+import type { CommentItem } from '@components/bottom-sheet/types/comment';
+
+export default function BoardDetailPage() {
+  const [isCommentDrawerOpen, setIsCommentDrawerOpen] = useState(false);
+
+  // Mock data - 실제로는 API에서 가져올 데이터
+  const comments: CommentItem[] = [
+    {
+      id: '550e8400-e29b-41d4-a716-446655440000',
+      author: '홍길동',
+      content: '좋은 글이네요!',
+      dateText: '1시간 전',
+      createdAt: '2025-12-01T05:22:40.043Z',
+      isUpdated: true,
+      likeCount: 5,
+      liked: true,
+      isMine: true,
+      replyCount: 0,
+    },
+    {
+      id: '550e8400-e29b-41d4-a716-446655440001',
+      author: '김철수',
+      content: '저도 같은 생각입니다. 정말 유익한 정보네요.',
+      dateText: '2시간 전',
+      createdAt: '2025-12-01T06:15:20.043Z',
+      isUpdated: false,
+      likeCount: 3,
+      liked: false,
+      isMine: false,
+      replyCount: 0,
+    },
+    {
+      id: '550e8400-e29b-41d4-a716-446655440002',
+      author: '이영희',
+      content: '공감합니다. 다음에도 이런 내용 기대할게요!',
+      dateText: '3시간 전',
+      createdAt: '2025-12-01T07:30:15.043Z',
+      isUpdated: false,
+      likeCount: 8,
+      liked: true,
+      isMine: false,
+      replyCount: 0,
+    },
+  ];
+
+  const handleCommentSectionClick = () => {
+    setIsCommentDrawerOpen(true);
+  };
+
+  const handleCloseDrawer = () => {
+    setIsCommentDrawerOpen(false);
+  };
+
+  const handleToggleLike = (kind: 'comment' | 'reply', id: string, parentId?: string) => {
+    // TODO: API 연동 - 좋아요 토글
+    console.log('Toggle like:', { kind, id, parentId });
+  };
+
+  const handleSendComment = async (text: string) => {
+    // TODO: API 연동 - 댓글 작성
+    console.log('Send comment:', text);
+    return true;
+  };
+
+  return (
+    <main className='flex-col gap-[1.5rem] px-[1.5rem] py-[2.5rem]'>
+      <header className='flex gap-[1rem]'>
+        <img className='h-[4rem] w-[4rem] rounded-full bg-gray-100'></img>
+        <div className='flex-col gap-[0.2rem]'>
+          <h1 className='caption1'>닉네임</h1>
+          <p className='caption5 rounded-[2px] bg-gray-100 px-[7px] text-gray-600'>2025.09.21</p>
+        </div>
+      </header>
+      <section className='body4 min-h-[400px] border-b-1 border-gray-200 p-[1.5rem] text-gray-900'>
+        description....
+      </section>
+      {/* 댓글 섹션 */}
+      <section>
+        {!isCommentDrawerOpen && (
+          <button type='button' onClick={handleCommentSectionClick} className='flex w-full cursor-pointer gap-[1rem]'>
+            <span className='flex-items-center gap-[2px]'>
+              <Icon name='comment' size={2.4} className='text-primary-900'></Icon>
+              <p className='caption1'>{comments.length}</p>
+            </span>
+            <span className='flex-items-center gap-[2px]'>
+              <Icon name='heart' size={2} className='text-system-error'></Icon>
+              <p className='caption1'>3</p>
+            </span>
+          </button>
+        )}
+      </section>
+
+      <CommentBottomSheet
+        open={isCommentDrawerOpen}
+        onClose={handleCloseDrawer}
+        comments={comments}
+        onToggleLike={handleToggleLike}
+        onSend={handleSendComment}
+      />
+    </main>
+  );
+}

--- a/src/pages/board/board-detail-page.tsx
+++ b/src/pages/board/board-detail-page.tsx
@@ -1,48 +1,61 @@
 import { useState, useMemo, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation } from '@tanstack/react-query';
 import Icon from '@components/icon';
 import CommentBottomSheet from '@components/bottom-sheet/comment-bottom-sheet';
 import type { CommentItem } from '@components/bottom-sheet/types/comment';
 import { boardQueries } from '@apis/board/board-queries';
+import { boardMutations } from '@apis/board/board-mutations';
 import { useHeaderOverride } from '@contexts/header-context';
 import type { ActionId } from '@layouts/header';
 import { modal } from '@libs/modal';
 import { toast } from '@libs/toast';
+import SelectBottomSheet from '@components/bottom-sheet/select-bottom-sheet';
+import { REVIEW_MANAGE_OPTIONS, type ReviewManage } from '@components/dropdown/constants/select-options';
 
 export default function BoardDetailPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const [isCommentDrawerOpen, setIsCommentDrawerOpen] = useState(false);
+  const [isManageBottomSheetOpen, setIsManageBottomSheetOpen] = useState(false);
+  const [selectedManageOption, setSelectedManageOption] = useState<ReviewManage | null>(null);
 
   const { data: boardDetail, isLoading } = useQuery(boardQueries.GET_BOARD_DETAIL(id!));
+  const { mutate: deleteBoard } = useMutation(boardMutations.DELETE_BOARD(id!));
 
-  // useCallback으로 핸들러 메모이제이션
-  const handleKebabClick = useCallback(async () => {
-    const result = await modal.confirm({
-      title: '게시글 관리',
-      confirmText: '삭제',
-      cancelText: '수정',
-    });
+  const handleKebabClick = useCallback(() => {
+    setIsManageBottomSheetOpen(true);
+  }, []);
 
-    if (result.ok) {
-      // 삭제
-      const confirmDelete = await modal.confirm({
-        title: '게시글 삭제',
-        confirmText: '삭제',
-        cancelText: '취소',
-      });
+  const handleManageOptionChange = useCallback(
+    async (option: string) => {
+      setSelectedManageOption(option as 'modify' | 'delete');
+      setIsManageBottomSheetOpen(false);
 
-      if (confirmDelete.ok) {
-        // TODO: 삭제 API 연동
-        toast.success('게시글이 삭제되었습니다');
-        navigate('/board');
+      if (option === 'modify') {
+        navigate(`/board/${id}/edit`);
+      } else if (option === 'delete') {
+        const confirmDelete = await modal.confirm({
+          title: '정말 삭제하시겠습니까?',
+          confirmText: '확인',
+          cancelText: '취소',
+        });
+
+        if (confirmDelete.ok) {
+          deleteBoard(undefined, {
+            onSuccess: () => {
+              toast.success('게시글이 삭제되었습니다');
+              navigate('/board');
+            },
+            onError: () => {
+              toast.error('게시글 삭제에 실패했습니다');
+            },
+          });
+        }
       }
-    } else {
-      // 수정
-      navigate(`/board/${id}/edit`);
-    }
-  }, [id, navigate]);
+    },
+    [id, navigate, deleteBoard]
+  );
 
   const headerConfig = useMemo(() => {
     if (!boardDetail) return null;
@@ -190,6 +203,14 @@ export default function BoardDetailPage() {
         comments={comments}
         onToggleLike={handleToggleLike}
         onSend={handleSendComment}
+      />
+
+      <SelectBottomSheet
+        open={isManageBottomSheetOpen}
+        onClose={() => setIsManageBottomSheetOpen(false)}
+        options={REVIEW_MANAGE_OPTIONS}
+        value={selectedManageOption}
+        onChange={handleManageOptionChange}
       />
     </main>
   );

--- a/src/pages/board/board-detail-page.tsx
+++ b/src/pages/board/board-detail-page.tsx
@@ -1,18 +1,66 @@
-import { useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useState, useMemo, useCallback } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import Icon from '@components/icon';
 import CommentBottomSheet from '@components/bottom-sheet/comment-bottom-sheet';
 import type { CommentItem } from '@components/bottom-sheet/types/comment';
 import { boardQueries } from '@apis/board/board-queries';
+import { useHeaderOverride } from '@contexts/header-context';
+import type { ActionId } from '@layouts/header';
+import { modal } from '@libs/modal';
+import { toast } from '@libs/toast';
 
 export default function BoardDetailPage() {
   const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
   const [isCommentDrawerOpen, setIsCommentDrawerOpen] = useState(false);
 
-  console.log(id);
-
   const { data: boardDetail, isLoading } = useQuery(boardQueries.GET_BOARD_DETAIL(id!));
+
+  // useCallback으로 핸들러 메모이제이션
+  const handleKebabClick = useCallback(async () => {
+    const result = await modal.confirm({
+      title: '게시글 관리',
+      confirmText: '삭제',
+      cancelText: '수정',
+    });
+
+    if (result.ok) {
+      // 삭제
+      const confirmDelete = await modal.confirm({
+        title: '게시글 삭제',
+        confirmText: '삭제',
+        cancelText: '취소',
+      });
+
+      if (confirmDelete.ok) {
+        // TODO: 삭제 API 연동
+        toast.success('게시글이 삭제되었습니다');
+        navigate('/board');
+      }
+    } else {
+      // 수정
+      navigate(`/board/${id}/edit`);
+    }
+  }, [id, navigate]);
+
+  const headerConfig = useMemo(() => {
+    if (!boardDetail) return null;
+
+    return {
+      left: 'back' as const,
+      safeTop: true,
+      title: boardDetail.title,
+      actions: boardDetail.isOwner ? ['kebab' as const] : [],
+      onAction: (action: ActionId) => {
+        if (action === 'kebab') {
+          handleKebabClick();
+        }
+      },
+    };
+  }, [boardDetail, handleKebabClick]);
+
+  useHeaderOverride(headerConfig);
 
   const comments: CommentItem[] = [
     {
@@ -110,10 +158,10 @@ export default function BoardDetailPage() {
         </div>
       </header>
 
-      <section className='flex-col gap-[1rem]'>
-        {/* <h2 className='title4 text-gray-900'>{boardDetail.title}</h2> */}
+      <section className='flex-col gap-[1rem] pt-5'>
+        <h2 className='title4 text-gray-900'>{boardDetail.title}</h2>
         <div
-          className='body4 min-h-[400px] border-b-1 border-gray-200 py-[1.5rem] text-gray-900'
+          className='body4 min-h-[400px] border-b-1 border-gray-200 text-gray-700'
           style={{ whiteSpace: 'pre-line' }}
         >
           {boardDetail.content}

--- a/src/pages/board/board-detail-page.tsx
+++ b/src/pages/board/board-detail-page.tsx
@@ -1,64 +1,25 @@
-import { useState, useMemo, useCallback } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
-import { useQuery, useMutation } from '@tanstack/react-query';
+import { useState, useMemo } from 'react';
+import { useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
 import Icon from '@components/icon';
 import CommentBottomSheet from '@components/bottom-sheet/comment-bottom-sheet';
 import type { CommentItem } from '@components/bottom-sheet/types/comment';
 import { boardQueries } from '@apis/board/board-queries';
-import { boardMutations } from '@apis/board/board-mutations';
 import { useHeaderOverride } from '@contexts/header-context';
 import type { ActionId } from '@layouts/header';
-import { modal } from '@libs/modal';
-import { toast } from '@libs/toast';
 import SelectBottomSheet from '@components/bottom-sheet/select-bottom-sheet';
-import { REVIEW_MANAGE_OPTIONS, type ReviewManage } from '@components/dropdown/constants/select-options';
+import { REVIEW_MANAGE_OPTIONS } from '@components/dropdown/constants/select-options';
+import { useBoardLike } from './hooks/use-board-like';
+import { useBoardManagement } from './hooks/use-board-management';
 
 export default function BoardDetailPage() {
   const { id } = useParams<{ id: string }>();
-  const navigate = useNavigate();
   const [isCommentDrawerOpen, setIsCommentDrawerOpen] = useState(false);
-  const [isManageBottomSheetOpen, setIsManageBottomSheetOpen] = useState(false);
-  const [selectedManageOption, setSelectedManageOption] = useState<ReviewManage | null>(null);
 
   const { data: boardDetail, isLoading } = useQuery(boardQueries.GET_BOARD_DETAIL(id!));
-  const { data: isLiked = false } = useQuery(boardQueries.GET_BOARD_LIKE(id!));
-  const { mutate: deleteBoard } = useMutation(boardMutations.DELETE_BOARD(id!));
-  const { mutate: addLike } = useMutation(boardMutations.POST_BOARD_LIKE(id!));
-  const { mutate: removeLike } = useMutation(boardMutations.DELETE_BOARD_LIKE(id!));
-
-  const handleKebabClick = useCallback(() => {
-    setIsManageBottomSheetOpen(true);
-  }, []);
-
-  const handleManageOptionChange = useCallback(
-    async (option: string) => {
-      setSelectedManageOption(option as 'modify' | 'delete');
-      setIsManageBottomSheetOpen(false);
-
-      if (option === 'modify') {
-        navigate(`/board-create?id=${id}`);
-      } else if (option === 'delete') {
-        const confirmDelete = await modal.confirm({
-          title: '정말 삭제하시겠습니까?',
-          confirmText: '확인',
-          cancelText: '취소',
-        });
-
-        if (confirmDelete.ok) {
-          deleteBoard(undefined, {
-            onSuccess: () => {
-              toast.success('게시글이 삭제되었습니다');
-              navigate('/board');
-            },
-            onError: () => {
-              toast.error('게시글 삭제에 실패했습니다');
-            },
-          });
-        }
-      }
-    },
-    [id, navigate, deleteBoard]
-  );
+  const { isLiked, toggleLike } = useBoardLike(id!);
+  const { isManageBottomSheetOpen, selectedManageOption, openManageSheet, closeManageSheet, handleManageOptionChange } =
+    useBoardManagement(id!);
 
   const headerConfig = useMemo(() => {
     if (!boardDetail) return null;
@@ -70,11 +31,11 @@ export default function BoardDetailPage() {
       actions: boardDetail.isOwner ? ['kebab' as const] : [],
       onAction: (action: ActionId) => {
         if (action === 'kebab') {
-          handleKebabClick();
+          openManageSheet();
         }
       },
     };
-  }, [boardDetail, handleKebabClick]);
+  }, [boardDetail, openManageSheet]);
 
   useHeaderOverride(headerConfig);
 
@@ -120,32 +81,6 @@ export default function BoardDetailPage() {
   const handleCommentSectionClick = () => {
     setIsCommentDrawerOpen(true);
   };
-
-  const handleCloseDrawer = () => {
-    setIsCommentDrawerOpen(false);
-  };
-
-  const handleBoardLikeClick = useCallback(() => {
-    if (isLiked) {
-      removeLike(undefined, {
-        onSuccess: () => {
-          toast.success('게시글 좋아요를 취소했습니다');
-        },
-        onError: () => {
-          toast.error('좋아요 취소에 실패했습니다');
-        },
-      });
-    } else {
-      addLike(undefined, {
-        onSuccess: () => {
-          toast.success('게시글에 좋아요를 눌렀습니다!');
-        },
-        onError: () => {
-          toast.error('좋아요에 실패했습니다');
-        },
-      });
-    }
-  }, [isLiked, addLike, removeLike]);
 
   const handleCommentToggleLike = (kind: 'comment' | 'reply', id: string, parentId?: string) => {
     // TODO: 댓글 좋아요 API 연동
@@ -215,7 +150,7 @@ export default function BoardDetailPage() {
                 <p className='caption1'>{boardDetail.commentCount}</p>
               </span>
             </button>
-            <button type='button' onClick={handleBoardLikeClick} className='cursor-pointer'>
+            <button type='button' onClick={toggleLike} className='cursor-pointer'>
               <span className='flex-items-center gap-[2px]'>
                 <Icon name={isLiked ? 'heart-fill' : 'heart'} size={2.4} className='text-system-error'></Icon>
                 <p className='caption1'>{boardDetail.likeCount}</p>
@@ -227,7 +162,7 @@ export default function BoardDetailPage() {
 
       <CommentBottomSheet
         open={isCommentDrawerOpen}
-        onClose={handleCloseDrawer}
+        onClose={() => setIsCommentDrawerOpen(false)}
         comments={comments}
         onToggleLike={handleCommentToggleLike}
         onSend={handleSendComment}
@@ -235,7 +170,7 @@ export default function BoardDetailPage() {
 
       <SelectBottomSheet
         open={isManageBottomSheetOpen}
-        onClose={() => setIsManageBottomSheetOpen(false)}
+        onClose={closeManageSheet}
         options={REVIEW_MANAGE_OPTIONS}
         value={selectedManageOption}
         onChange={handleManageOptionChange}

--- a/src/pages/board/board-page.tsx
+++ b/src/pages/board/board-page.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState, useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
 import PostCard from '@pages/board/components/post-card';
 import type { IGroupCard } from '@pages/home/types/home.types';
 import PillTab from '@components/tab/pill-tab';
@@ -7,6 +8,9 @@ import UnderlineTab from '@components/tab/underline-tab';
 import SelectDropdown from '@components/dropdown/select-dropdown';
 import GroupCard from '@pages/home/components/card/group-card';
 import { cn } from '@libs/cn';
+import { useQuery } from '@tanstack/react-query';
+import { boardQueries } from '@apis/board/board-queries';
+import { formatDate } from '@/shared/utils/formatDate';
 
 type TabItem = { key: string; label: string };
 
@@ -22,15 +26,19 @@ const CATEGORIES: TabItem[] = [
   { key: 'gather', label: '모임 모집' },
 ];
 
-type Post = {
-  id: string;
-  title: string;
-  content: string;
-  commentCount: number;
-  likeCount: number;
-  date: string;
-  author: string;
-  category: string;
+// UI 카테고리를 API 카테고리로 변환
+const mapCategoryToApi = (category: string): string | undefined => {
+  switch (category) {
+    case 'recommend':
+      return 'RECOMMEND';
+    case 'daily':
+      return 'GENERAL';
+    case 'gather':
+      return 'POPULAR';
+    case 'all':
+    default:
+      return undefined;
+  }
 };
 
 type SortType = 'latest' | 'popular';
@@ -38,39 +46,6 @@ type SortType = 'latest' | 'popular';
 const SORT_OPTIONS: ReadonlyArray<{ value: SortType; label: string }> = [
   { value: 'latest', label: '최신순' },
   { value: 'popular', label: '인기순' },
-];
-
-const MOCK_POSTS: Post[] = [
-  {
-    id: 'p1',
-    title: '게시글 제목',
-    content: '내용이 여기에 들어갑니다. 내용이 여기에 들어갑니다. 내용이 여기에 들어갑니다. 내용이 여기에 들어갑니다.',
-    commentCount: 9,
-    likeCount: 9,
-    date: '2025.09.21',
-    author: '작성자이름',
-    category: 'all',
-  },
-  {
-    id: 'p2',
-    title: '게시글 제목',
-    content: '내용이 여기에 들어갑니다. 내용이 여기에 들어갑니다. 내용이 여기에 들어갑니다. 내용이 여기에 들어갑니다.',
-    commentCount: 9,
-    likeCount: 9,
-    date: '2025.09.21',
-    author: '작성자이름',
-    category: 'all',
-  },
-  {
-    id: 'p3',
-    title: '게시글 제목',
-    content: '내용이 여기에 들어갑니다. 내용이 여기에 들어갑니다. 내용이 여기에 들어갑니다. 내용이 여기에 들어갑니다.',
-    commentCount: 9,
-    likeCount: 9,
-    date: '2025.09.21',
-    author: '작성자이름',
-    category: 'all',
-  },
 ];
 
 const MOCK_GROUPS: IGroupCard[] = [
@@ -109,9 +84,11 @@ const MOCK_GROUPS: IGroupCard[] = [
 ];
 
 export default function BoardPage() {
+  const navigate = useNavigate();
   const [topTab, setTopTab] = useState<'community' | 'reading'>('community');
   const [category, setCategory] = useState<string>('all');
   const [sort, setSort] = useState<SortType>('latest');
+  const [searchKeyword, setSearchKeyword] = useState<string>('');
 
   const searchAnchorRef = useRef<HTMLDivElement | null>(null);
   const floatingSearchRef = useRef<HTMLDivElement | null>(null);
@@ -126,10 +103,24 @@ export default function BoardPage() {
     return () => io.disconnect();
   }, []);
 
+  const apiCategory = mapCategoryToApi(category);
+  const { data: boardPosts = [], isLoading } = useQuery(
+    boardQueries.GET_BOARD_LIST({
+      title: searchKeyword || undefined,
+      category: apiCategory,
+    })
+  );
+
   const filteredPosts = useMemo(() => {
-    const list = category === 'all' ? MOCK_POSTS : MOCK_POSTS.filter((p) => p.category === category);
-    return sort === 'popular' ? [...list].sort((a, b) => b.likeCount - a.likeCount) : list;
-  }, [category, sort]);
+    if (sort === 'popular') {
+      return [...boardPosts].sort((a, b) => b.likeCount - a.likeCount);
+    }
+    return boardPosts;
+  }, [boardPosts, sort]);
+
+  const handleSearch = (keyword: string) => {
+    setSearchKeyword(keyword);
+  };
 
   const searchPlaceholder = topTab === 'community' ? '검색어를 입력해 주세요.' : '독서모임명으로 검색';
 
@@ -147,12 +138,12 @@ export default function BoardPage() {
           ref={floatingSearchRef}
           className={cn('bg-gray-white sticky top-0 z-[var(--z-header)]', 'px-[2rem] pt-[0.8rem] pb-[0.8rem]')}
         >
-          <SearchBar placeholder={searchPlaceholder} />
+          <SearchBar placeholder={searchPlaceholder} onSubmit={handleSearch} />
         </div>
       )}
 
       <div className='px-[2rem] pt-[1.2rem]' ref={searchAnchorRef}>
-        <SearchBar placeholder={searchPlaceholder} />
+        <SearchBar placeholder={searchPlaceholder} onSubmit={handleSearch} />
       </div>
 
       {topTab === 'community' ? (
@@ -162,7 +153,7 @@ export default function BoardPage() {
             <div className='flex-row-between w-full px-[2rem]'>
               <div className='flex py-[1.2rem]'>
                 <span className='caption2 text-gray-900'>
-                  총 <span className='text-primary-700'>20개</span>
+                  총 <span className='text-primary-700'>{filteredPosts.length}개</span>
                 </span>
               </div>
 
@@ -179,20 +170,29 @@ export default function BoardPage() {
             </div>
           </div>
 
-          <ul className='space-y-[0.1rem]'>
-            {filteredPosts.map((p) => (
-              <li key={p.id} className='bg-gray-white'>
-                <PostCard
-                  title={p.title}
-                  content={p.content}
-                  commentCount={p.commentCount}
-                  likeCount={p.likeCount}
-                  date={p.date}
-                  author={p.author}
-                />
-              </li>
-            ))}
-          </ul>
+          {isLoading ? (
+            <div className='body5 py-[4rem] text-center text-gray-500'>로딩 중...</div>
+          ) : (
+            <ul className='space-y-[0.1rem]'>
+              {filteredPosts.length === 0 ? (
+                <li className='body5 py-[4rem] text-center text-gray-500'>게시글이 없습니다.</li>
+              ) : (
+                filteredPosts.map((post) => (
+                  <li key={post.id} className='bg-gray-white'>
+                    <PostCard
+                      title={post.title}
+                      content=''
+                      commentCount={post.commentCount}
+                      likeCount={post.likeCount}
+                      date={formatDate(post.createdAt)}
+                      author={post.writerName}
+                      onClick={() => navigate(`/board/${post.id}`)}
+                    />
+                  </li>
+                ))
+              )}
+            </ul>
+          )}
         </>
       ) : (
         <>

--- a/src/pages/board/board-page.tsx
+++ b/src/pages/board/board-page.tsx
@@ -1,5 +1,5 @@
-import { useMemo, useState, useEffect, useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import PostCard from '@pages/board/components/post-card';
 import type { IGroupCard } from '@pages/home/types/home.types';
 import PillTab from '@components/tab/pill-tab';
@@ -9,7 +9,7 @@ import SelectDropdown from '@components/dropdown/select-dropdown';
 import GroupCard from '@pages/home/components/card/group-card';
 import { cn } from '@libs/cn';
 import { useQuery } from '@tanstack/react-query';
-import { boardQueries } from '@apis/board/board-queries';
+import { boardQueries, type SortType } from '@apis/board/board-queries';
 import { formatDate } from '@/shared/utils/formatDate';
 
 export type TabItem = { key: string; label: string };
@@ -25,8 +25,6 @@ export const CATEGORIES: TabItem[] = [
   { key: 'GENERAL', label: '일상' },
   { key: 'GATHER', label: '모임 모집' },
 ];
-
-type SortType = 'LATEST' | 'POPULAR';
 
 const SORT_OPTIONS: ReadonlyArray<{ value: SortType; label: string }> = [
   { value: 'LATEST', label: '최신순' },
@@ -70,15 +68,30 @@ const MOCK_GROUPS: IGroupCard[] = [
 
 export default function BoardPage() {
   const navigate = useNavigate();
-  const [topTab, setTopTab] = useState<'community' | 'reading'>('community');
-  const [category, setCategory] = useState<string>('ALL');
-  const [sort, setSort] = useState<SortType>('LATEST');
-  const [searchKeyword, setSearchKeyword] = useState<string>('');
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const topTab = (searchParams.get('tab') as 'community' | 'reading') || 'community';
+  const category = searchParams.get('category') || 'ALL';
+  const sort = (searchParams.get('sort') as SortType) || 'LATEST';
+  const searchKeyword = searchParams.get('search') || '';
 
   const searchAnchorRef = useRef<HTMLDivElement | null>(null);
   const floatingSearchRef = useRef<HTMLDivElement | null>(null);
-
   const [showFloatingSearch, setShowFloatingSearch] = useState(false);
+
+  const updateParams = (updates: Record<string, string | undefined>) => {
+    const newParams = new URLSearchParams(searchParams);
+
+    Object.entries(updates).forEach(([key, value]) => {
+      if (value === undefined || value === '' || value === 'ALL' || value === 'LATEST') {
+        newParams.delete(key);
+      } else {
+        newParams.set(key, value);
+      }
+    });
+
+    setSearchParams(newParams, { replace: true });
+  };
 
   useEffect(() => {
     const el = searchAnchorRef.current;
@@ -92,18 +105,24 @@ export default function BoardPage() {
     boardQueries.GET_BOARD_LIST({
       title: searchKeyword || undefined,
       category: category === 'ALL' ? undefined : category,
+      sort,
     })
   );
 
-  const filteredPosts = useMemo(() => {
-    if (sort === 'POPULAR') {
-      return [...boardPosts].sort((a, b) => b.likeCount - a.likeCount);
-    }
-    return boardPosts;
-  }, [boardPosts, sort]);
+  const handleTabChange = (tab: string) => {
+    updateParams({ tab });
+  };
+
+  const handleCategoryChange = (cat: string) => {
+    updateParams({ category: cat });
+  };
+
+  const handleSortChange = (s: SortType) => {
+    updateParams({ sort: s });
+  };
 
   const handleSearch = (keyword: string) => {
-    setSearchKeyword(keyword);
+    updateParams({ search: keyword });
   };
 
   const searchPlaceholder = topTab === 'community' ? '검색어를 입력해 주세요.' : '독서모임명으로 검색';
@@ -113,7 +132,7 @@ export default function BoardPage() {
       <UnderlineTab
         items={COMMUNITY_TABS}
         value={topTab}
-        onChange={(k) => setTopTab(k as 'community' | 'reading')}
+        onChange={handleTabChange}
         className={cn('sticky', showFloatingSearch ? 'top-[6.5rem]' : 'top-0')}
       />
 
@@ -133,18 +152,18 @@ export default function BoardPage() {
       {topTab === 'community' ? (
         <>
           <div className='flex-col-center gap-[0.9rem]'>
-            <PillTab items={CATEGORIES} value={category} onChange={setCategory} />
+            <PillTab items={CATEGORIES} value={category} onChange={handleCategoryChange} />
             <div className='flex-row-between w-full px-[2rem]'>
               <div className='flex py-[1.2rem]'>
                 <span className='caption2 text-gray-900'>
-                  총 <span className='text-primary-700'>{filteredPosts.length}개</span>
+                  총 <span className='text-primary-700'>{boardPosts.length}개</span>
                 </span>
               </div>
 
               <SelectDropdown<SortType>
                 value={sort}
                 options={SORT_OPTIONS}
-                onChange={setSort}
+                onChange={handleSortChange}
                 align='end'
                 variant='title'
                 menuWidthRem={12}
@@ -158,14 +177,14 @@ export default function BoardPage() {
             <div className='body5 py-[4rem] text-center text-gray-500'>로딩 중...</div>
           ) : (
             <ul className='space-y-[0.1rem]'>
-              {filteredPosts.length === 0 ? (
+              {boardPosts.length === 0 ? (
                 <li className='body5 py-[4rem] text-center text-gray-500'>게시글이 없습니다.</li>
               ) : (
-                filteredPosts.map((post) => (
+                boardPosts.map((post) => (
                   <li key={post.id} className='bg-gray-white'>
                     <PostCard
                       title={post.title}
-                      content=''
+                      content={post.previewContent}
                       commentCount={post.commentCount}
                       likeCount={post.likeCount}
                       date={formatDate(post.createdAt)}

--- a/src/pages/board/board-page.tsx
+++ b/src/pages/board/board-page.tsx
@@ -12,40 +12,25 @@ import { useQuery } from '@tanstack/react-query';
 import { boardQueries } from '@apis/board/board-queries';
 import { formatDate } from '@/shared/utils/formatDate';
 
-type TabItem = { key: string; label: string };
+export type TabItem = { key: string; label: string };
 
 const COMMUNITY_TABS: TabItem[] = [
   { key: 'community', label: '커뮤니티' },
   { key: 'reading', label: '독서 모임' },
 ];
 
-const CATEGORIES: TabItem[] = [
-  { key: 'all', label: '전체' },
-  { key: 'recommend', label: '책 추천' },
-  { key: 'daily', label: '일상' },
-  { key: 'gather', label: '모임 모집' },
+export const CATEGORIES: TabItem[] = [
+  { key: 'ALL', label: '전체' },
+  { key: 'RECOMMEND', label: '책 추천' },
+  { key: 'GENERAL', label: '일상' },
+  { key: 'GATHER', label: '모임 모집' },
 ];
 
-// UI 카테고리를 API 카테고리로 변환
-const mapCategoryToApi = (category: string): string | undefined => {
-  switch (category) {
-    case 'recommend':
-      return 'RECOMMEND';
-    case 'daily':
-      return 'GENERAL';
-    case 'gather':
-      return 'POPULAR';
-    case 'all':
-    default:
-      return undefined;
-  }
-};
-
-type SortType = 'latest' | 'popular';
+type SortType = 'LATEST' | 'POPULAR';
 
 const SORT_OPTIONS: ReadonlyArray<{ value: SortType; label: string }> = [
-  { value: 'latest', label: '최신순' },
-  { value: 'popular', label: '인기순' },
+  { value: 'LATEST', label: '최신순' },
+  { value: 'POPULAR', label: '인기순' },
 ];
 
 const MOCK_GROUPS: IGroupCard[] = [
@@ -86,8 +71,8 @@ const MOCK_GROUPS: IGroupCard[] = [
 export default function BoardPage() {
   const navigate = useNavigate();
   const [topTab, setTopTab] = useState<'community' | 'reading'>('community');
-  const [category, setCategory] = useState<string>('all');
-  const [sort, setSort] = useState<SortType>('latest');
+  const [category, setCategory] = useState<string>('ALL');
+  const [sort, setSort] = useState<SortType>('LATEST');
   const [searchKeyword, setSearchKeyword] = useState<string>('');
 
   const searchAnchorRef = useRef<HTMLDivElement | null>(null);
@@ -103,16 +88,15 @@ export default function BoardPage() {
     return () => io.disconnect();
   }, []);
 
-  const apiCategory = mapCategoryToApi(category);
   const { data: boardPosts = [], isLoading } = useQuery(
     boardQueries.GET_BOARD_LIST({
       title: searchKeyword || undefined,
-      category: apiCategory,
+      category: category === 'ALL' ? undefined : category,
     })
   );
 
   const filteredPosts = useMemo(() => {
-    if (sort === 'popular') {
+    if (sort === 'POPULAR') {
       return [...boardPosts].sort((a, b) => b.likeCount - a.likeCount);
     }
     return boardPosts;

--- a/src/pages/board/board-page.tsx
+++ b/src/pages/board/board-page.tsx
@@ -71,16 +71,6 @@ const MOCK_POSTS: Post[] = [
     author: '작성자이름',
     category: 'all',
   },
-  {
-    id: 'p4',
-    title: '게시글 제목',
-    content: '내용이 여기에 들어갑니다. 내용이 여기에 들어갑니다. 내용이 여기에 들어갑니다. 내용이 여기에 들어갑니다.',
-    commentCount: 9,
-    likeCount: 9,
-    date: '2025.09.21',
-    author: '작성자이름',
-    category: 'all',
-  },
 ];
 
 const MOCK_GROUPS: IGroupCard[] = [
@@ -149,7 +139,7 @@ export default function BoardPage() {
         items={COMMUNITY_TABS}
         value={topTab}
         onChange={(k) => setTopTab(k as 'community' | 'reading')}
-        className={cn('sticky', showFloatingSearch ? 'top-[6.6rem]' : 'top-0')}
+        className={cn('sticky', showFloatingSearch ? 'top-[6.5rem]' : 'top-0')}
       />
 
       {showFloatingSearch && (

--- a/src/pages/board/components/post-card.tsx
+++ b/src/pages/board/components/post-card.tsx
@@ -43,12 +43,12 @@ export default function PostCard({
 
       <div className='flex flex-wrap items-center gap-[0.5rem]'>
         <div className='flex items-center gap-[0.3rem]'>
-          <Icon name='comment' size={1.6} ariaHidden />
+          <Icon name='comment' size={1.6} ariaHidden className='text-primary-900' />
           <span className='caption5'>{commentCount}</span>
         </div>
 
         <div className='flex items-center gap-[0.3rem]'>
-          <Icon name='heart' size={1.6} ariaHidden />
+          <Icon name='heart' size={1.6} ariaHidden className='text-system-error' />
           <span className='caption5'>{likeCount}</span>
         </div>
 

--- a/src/pages/board/components/post-card.tsx
+++ b/src/pages/board/components/post-card.tsx
@@ -30,6 +30,7 @@ export default function PostCard({
         'bg-gray-white w-full border-t border-gray-200',
         'px-[2rem] py-[1.5rem] text-gray-900',
         'flex-col justify-start gap-[1rem]',
+        'cursor-pointer',
         className
       )}
     >

--- a/src/pages/board/hooks/use-board-like.ts
+++ b/src/pages/board/hooks/use-board-like.ts
@@ -1,0 +1,35 @@
+import { useCallback } from 'react';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { boardQueries } from '@apis/board/board-queries';
+import { boardMutations } from '@apis/board/board-mutations';
+import { toast } from '@libs/toast';
+
+export function useBoardLike(boardId: string) {
+  const { data: isLiked = false } = useQuery(boardQueries.GET_BOARD_LIKE(boardId));
+  const { mutate: addLike } = useMutation(boardMutations.POST_BOARD_LIKE(boardId));
+  const { mutate: removeLike } = useMutation(boardMutations.DELETE_BOARD_LIKE(boardId));
+
+  const toggleLike = useCallback(() => {
+    if (isLiked) {
+      removeLike(undefined, {
+        onSuccess: () => {
+          toast.success('게시글 좋아요를 취소했습니다');
+        },
+        onError: () => {
+          toast.error('좋아요 취소에 실패했습니다');
+        },
+      });
+    } else {
+      addLike(undefined, {
+        onSuccess: () => {
+          toast.success('게시글에 좋아요를 눌렀습니다!');
+        },
+        onError: () => {
+          toast.error('좋아요에 실패했습니다');
+        },
+      });
+    }
+  }, [isLiked, addLike, removeLike]);
+
+  return { isLiked, toggleLike };
+}

--- a/src/pages/board/hooks/use-board-management.ts
+++ b/src/pages/board/hooks/use-board-management.ts
@@ -1,0 +1,60 @@
+import { useState, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useMutation } from '@tanstack/react-query';
+import { boardMutations } from '@apis/board/board-mutations';
+import { modal } from '@libs/modal';
+import { toast } from '@libs/toast';
+import type { ReviewManage } from '@components/dropdown/constants/select-options';
+
+export function useBoardManagement(boardId: string) {
+  const navigate = useNavigate();
+  const [isManageBottomSheetOpen, setIsManageBottomSheetOpen] = useState(false);
+  const [selectedManageOption, setSelectedManageOption] = useState<ReviewManage | null>(null);
+  const { mutate: deleteBoard } = useMutation(boardMutations.DELETE_BOARD(boardId));
+
+  const openManageSheet = useCallback(() => {
+    setIsManageBottomSheetOpen(true);
+  }, []);
+
+  const closeManageSheet = useCallback(() => {
+    setIsManageBottomSheetOpen(false);
+  }, []);
+
+  const handleManageOptionChange = useCallback(
+    async (option: string) => {
+      setSelectedManageOption(option as ReviewManage);
+      setIsManageBottomSheetOpen(false);
+
+      if (option === 'modify') {
+        navigate(`/board-create?id=${boardId}`);
+      } else if (option === 'delete') {
+        const confirmDelete = await modal.confirm({
+          title: '정말 삭제하시겠습니까?',
+          confirmText: '확인',
+          cancelText: '취소',
+        });
+
+        if (confirmDelete.ok) {
+          deleteBoard(undefined, {
+            onSuccess: () => {
+              toast.success('게시글이 삭제되었습니다');
+              navigate('/board');
+            },
+            onError: () => {
+              toast.error('게시글 삭제에 실패했습니다');
+            },
+          });
+        }
+      }
+    },
+    [boardId, navigate, deleteBoard]
+  );
+
+  return {
+    isManageBottomSheetOpen,
+    selectedManageOption,
+    openManageSheet,
+    closeManageSheet,
+    handleManageOptionChange,
+  };
+}

--- a/src/pages/library/book-detail-page.tsx
+++ b/src/pages/library/book-detail-page.tsx
@@ -32,19 +32,6 @@ export default function BookDetailPage() {
 
   const handleCartClick = async (e: React.MouseEvent) => {
     e.stopPropagation();
-    if (book) {
-      // await addToCart({
-      //   id: String(book.id),
-      //   title: book.title,
-      //   author: book.author,
-      //   library: book.library,
-      //   dueDate: new Date(Date.now() + book.maxDays * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
-      //   maxDays: book.maxDays,
-      //   deposit: book.deposit,
-      //   status: book.status,
-      //   imgUrl: book.imgUrl,
-      // });
-    }
   };
 
   if (!book) {

--- a/src/shared/apis/base/client.ts
+++ b/src/shared/apis/base/client.ts
@@ -1,5 +1,7 @@
-import axios, { type AxiosError } from 'axios';
+import axios, { type AxiosError, type InternalAxiosRequestConfig } from 'axios';
 import { ERROR_CODES, ERROR_MESSAGES, HTTP_STATUS } from '@constants/http';
+import { END_POINT } from '@constants/end-point';
+import { getAccessToken, removeAccessToken, setAccessToken } from '@/shared/utils/auth';
 
 export interface ApiResponse<T = unknown> {
   success: boolean;
@@ -60,6 +62,7 @@ const createHttpClient = (baseURL: string) => {
   const instance = axios.create({
     baseURL,
     timeout: 10000,
+    withCredentials: true,
     headers: {
       'Content-Type': 'application/json',
     },
@@ -67,7 +70,7 @@ const createHttpClient = (baseURL: string) => {
 
   instance.interceptors.request.use(
     (config) => {
-      const token = localStorage.getItem('accessToken');
+      const token = getAccessToken();
       if (token) {
         config.headers.Authorization = `Bearer ${token}`;
       }
@@ -88,10 +91,25 @@ const createHttpClient = (baseURL: string) => {
       return response;
     },
     async (error: AxiosError<ApiResponse>) => {
+      const originalRequest = error.config as InternalAxiosRequestConfig & { _retry?: boolean };
       const status = error.response?.status;
 
-      if (status === HTTP_STATUS.UNAUTHORIZED) {
-        // 401 오류처리
+      if (status === HTTP_STATUS.UNAUTHORIZED && !originalRequest._retry) {
+        originalRequest._retry = true;
+
+        try {
+          const response = await instance.post<ApiResponse<string>>(END_POINT.TOKEN_REISSUE, {});
+          const newAccessToken = response.data.data;
+
+          if (newAccessToken) {
+            setAccessToken(newAccessToken);
+            originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+            return instance(originalRequest);
+          }
+        } catch (refreshError) {
+          removeAccessToken();
+          return Promise.reject(refreshError);
+        }
       }
 
       const apiError = handleError(error);

--- a/src/shared/apis/board/board-mutations.ts
+++ b/src/shared/apis/board/board-mutations.ts
@@ -62,4 +62,36 @@ export const boardMutations = {
         queryClient.removeQueries({ queryKey: queryKeys.board.detail(id) });
       },
     }),
+
+  POST_BOARD_LIKE: (id: string) =>
+    mutationOptions<boolean, Error, void>({
+      mutationKey: mutationKeys.board.like,
+      mutationFn: () =>
+        post<boolean>(END_POINT.BOARD_LIKE(id), undefined, {
+          headers: {
+            'Trace-Id': uuidv4(),
+          },
+        }),
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: queryKeys.board.like(id) });
+        queryClient.invalidateQueries({ queryKey: queryKeys.board.detail(id) });
+        queryClient.invalidateQueries({ queryKey: queryKeys.board.lists() });
+      },
+    }),
+
+  DELETE_BOARD_LIKE: (id: string) =>
+    mutationOptions<boolean, Error, void>({
+      mutationKey: mutationKeys.board.like,
+      mutationFn: () =>
+        del<boolean>(END_POINT.BOARD_LIKE(id), {
+          headers: {
+            'Trace-Id': uuidv4(),
+          },
+        }),
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: queryKeys.board.like(id) });
+        queryClient.invalidateQueries({ queryKey: queryKeys.board.detail(id) });
+        queryClient.invalidateQueries({ queryKey: queryKeys.board.lists() });
+      },
+    }),
 };

--- a/src/shared/apis/board/board-mutations.ts
+++ b/src/shared/apis/board/board-mutations.ts
@@ -1,4 +1,4 @@
-import { post, del } from '@apis/base/client';
+import { post, put, del } from '@apis/base/client';
 import { END_POINT } from '@constants/end-point';
 import { mutationKeys, queryKeys } from '@constants/query-keys';
 import queryClient from '@libs/query-client';
@@ -10,6 +10,12 @@ export interface ICreateBoardParams {
   title: string;
   content: string;
   category: BoardCategory;
+}
+
+export interface IUpdateBoardParams {
+  boardId: string;
+  title: string;
+  content: string;
 }
 
 export const boardMutations = {
@@ -24,6 +30,21 @@ export const boardMutations = {
         }),
       onSuccess: () => {
         queryClient.invalidateQueries({ queryKey: queryKeys.board.lists() });
+      },
+    }),
+
+  PUT_BOARD: () =>
+    mutationOptions<string, Error, IUpdateBoardParams>({
+      mutationKey: mutationKeys.board.update,
+      mutationFn: (data) =>
+        put<string>(END_POINT.BOARD, data, {
+          headers: {
+            'Trace-Id': uuidv4(),
+          },
+        }),
+      onSuccess: (_, variables) => {
+        queryClient.invalidateQueries({ queryKey: queryKeys.board.lists() });
+        queryClient.invalidateQueries({ queryKey: queryKeys.board.detail(variables.boardId) });
       },
     }),
 

--- a/src/shared/apis/board/board-mutations.ts
+++ b/src/shared/apis/board/board-mutations.ts
@@ -1,4 +1,4 @@
-import { post } from '@apis/base/client';
+import { post, del } from '@apis/base/client';
 import { END_POINT } from '@constants/end-point';
 import { mutationKeys, queryKeys } from '@constants/query-keys';
 import queryClient from '@libs/query-client';
@@ -24,6 +24,21 @@ export const boardMutations = {
         }),
       onSuccess: () => {
         queryClient.invalidateQueries({ queryKey: queryKeys.board.lists() });
+      },
+    }),
+
+  DELETE_BOARD: (id: string) =>
+    mutationOptions<boolean, Error, void>({
+      mutationKey: mutationKeys.board.delete,
+      mutationFn: () =>
+        del<boolean>(END_POINT.BOARD_BY_ID(id), {
+          headers: {
+            'Trace-Id': uuidv4(),
+          },
+        }),
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: queryKeys.board.lists() });
+        queryClient.removeQueries({ queryKey: queryKeys.board.detail(id) });
       },
     }),
 };

--- a/src/shared/apis/board/board-mutations.ts
+++ b/src/shared/apis/board/board-mutations.ts
@@ -1,0 +1,29 @@
+import { post } from '@apis/base/client';
+import { END_POINT } from '@constants/end-point';
+import { mutationKeys, queryKeys } from '@constants/query-keys';
+import queryClient from '@libs/query-client';
+import { mutationOptions } from '@tanstack/react-query';
+import { v4 as uuidv4 } from 'uuid';
+import type { BoardCategory } from './board-queries';
+
+export interface ICreateBoardParams {
+  title: string;
+  content: string;
+  category: BoardCategory;
+}
+
+export const boardMutations = {
+  POST_BOARD: () =>
+    mutationOptions<string, Error, ICreateBoardParams>({
+      mutationKey: mutationKeys.board.create,
+      mutationFn: (data) =>
+        post<string>(END_POINT.BOARD, data, {
+          headers: {
+            'Trace-Id': uuidv4(),
+          },
+        }),
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: queryKeys.board.lists() });
+      },
+    }),
+};

--- a/src/shared/apis/board/board-queries.ts
+++ b/src/shared/apis/board/board-queries.ts
@@ -1,0 +1,50 @@
+import { get } from '@apis/base/client';
+import { END_POINT } from '@constants/end-point';
+import { queryKeys } from '@constants/query-keys';
+import { queryOptions } from '@tanstack/react-query';
+
+export type BoardCategory = 'GENERAL' | 'POPULAR' | 'RECOMMEND';
+
+export interface IBoardPost {
+  id: string;
+  writerName: string;
+  title: string;
+  createdAt: string;
+  likeCount: number;
+  commentCount: number;
+  category: BoardCategory;
+  viewCount: number;
+}
+
+export interface IBoardDetail extends IBoardPost {
+  content: string;
+  isUpdated: boolean;
+  isOwner: boolean;
+}
+
+interface IBoardListParams {
+  title?: string;
+  category?: string;
+}
+
+export const boardQueries = {
+  GET_BOARD_LIST: (params: IBoardListParams = {}) =>
+    queryOptions<IBoardPost[]>({
+      queryKey: queryKeys.board.list(params),
+      queryFn: async () => {
+        const res = await get<IBoardPost[]>(END_POINT.BOARD, {
+          params,
+        });
+        return res;
+      },
+    }),
+
+  GET_BOARD_DETAIL: (id: string) =>
+    queryOptions<IBoardDetail>({
+      queryKey: queryKeys.board.detail(id),
+      queryFn: async () => {
+        const res = await get<IBoardDetail>(END_POINT.BOARD_BY_ID(id));
+        return res;
+      },
+    }),
+};

--- a/src/shared/apis/board/board-queries.ts
+++ b/src/shared/apis/board/board-queries.ts
@@ -50,4 +50,13 @@ export const boardQueries = {
         return res;
       },
     }),
+
+  GET_BOARD_LIKE: (id: string) =>
+    queryOptions<boolean>({
+      queryKey: queryKeys.board.like(id),
+      queryFn: async () => {
+        const res = await get<boolean>(END_POINT.BOARD_LIKE(id));
+        return res;
+      },
+    }),
 };

--- a/src/shared/apis/board/board-queries.ts
+++ b/src/shared/apis/board/board-queries.ts
@@ -3,7 +3,8 @@ import { END_POINT } from '@constants/end-point';
 import { queryKeys } from '@constants/query-keys';
 import { queryOptions } from '@tanstack/react-query';
 
-export type BoardCategory = 'GENERAL' | 'POPULAR' | 'RECOMMEND';
+export type BoardCategory = 'GENERAL' | 'RECOMMEND' | 'GATHER' | 'POPULAR';
+export type SortType = 'LATEST' | 'POPULAR';
 
 export interface IBoardPost {
   id: string;
@@ -12,6 +13,7 @@ export interface IBoardPost {
   createdAt: string;
   likeCount: number;
   commentCount: number;
+  previewContent: string;
   category: BoardCategory;
   viewCount: number;
 }
@@ -25,6 +27,7 @@ export interface IBoardDetail extends IBoardPost {
 interface IBoardListParams {
   title?: string;
   category?: string;
+  sort?: SortType;
 }
 
 export const boardQueries = {

--- a/src/shared/components/bottom-sheet/comment-bottom-sheet.tsx
+++ b/src/shared/components/bottom-sheet/comment-bottom-sheet.tsx
@@ -19,8 +19,8 @@ export default function CommentBottomSheet(props: CommentProps) {
   } = props;
 
   const [text, setText] = useState('');
-  const [openReplies, setOpenReplies] = useState<Record<number, boolean>>({});
-  const [replyTargetId, setReplyTargetId] = useState<number | null>(null);
+  const [openReplies, setOpenReplies] = useState<Record<string, boolean>>({});
+  const [replyTargetId, setReplyTargetId] = useState<string | null>(null);
 
   const canSend = useMemo(() => text.trim().length > 0, [text]);
 
@@ -42,7 +42,7 @@ export default function CommentBottomSheet(props: CommentProps) {
     setReplyTargetId(null);
   };
 
-  const toggleReplies = async (parentId: number) => {
+  const toggleReplies = async (parentId: string) => {
     const next = !openReplies[parentId];
     setOpenReplies((m) => ({ ...m, [parentId]: next }));
     if (next) await onLoadReplies?.(parentId);

--- a/src/shared/components/bottom-sheet/types/comment.ts
+++ b/src/shared/components/bottom-sheet/types/comment.ts
@@ -1,5 +1,5 @@
 export type ReplyItem = {
-  id: number;
+  id: string;
   avatarUrl?: string;
   author: string;
   dateText: string;
@@ -7,10 +7,13 @@ export type ReplyItem = {
   likeCount: number;
   liked?: boolean;
   disabled?: boolean;
+  isUpdated?: boolean;
+  isMine?: boolean;
+  createdAt?: string;
 };
 
 export type CommentItem = {
-  id: number;
+  id: string;
   avatarUrl?: string;
   author: string;
   dateText: string;
@@ -22,6 +25,9 @@ export type CommentItem = {
   replies?: ReplyItem[];
   liked?: boolean;
   disabled?: boolean;
+  isUpdated?: boolean;
+  isMine?: boolean;
+  createdAt?: string;
 };
 
 export type ToggleLikeKind = 'comment' | 'reply';
@@ -30,11 +36,11 @@ export type CommentProps = {
   open: boolean;
   onClose: () => void;
   comments: readonly CommentItem[];
-  onToggleLike?: (kind: ToggleLikeKind, id: number, parentId?: number) => void;
-  onReplyClick?: (parentId: number) => void;
+  onToggleLike?: (kind: ToggleLikeKind, id: string, parentId?: string) => void;
+  onReplyClick?: (parentId: string) => void;
   onSend?: (text: string) => boolean | void | Promise<boolean | void>;
-  onSendReply?: (parentId: number, text: string) => boolean | void | Promise<boolean | void>;
-  onLoadReplies?: (parentId: number) => Promise<ReplyItem[] | void> | void;
+  onSendReply?: (parentId: string, text: string) => boolean | void | Promise<boolean | void>;
+  onLoadReplies?: (parentId: string) => Promise<ReplyItem[] | void> | void;
   indicatorStroke?: boolean;
   emptyText?: string;
   title?: string;

--- a/src/shared/components/button/circle-button.tsx
+++ b/src/shared/components/button/circle-button.tsx
@@ -2,7 +2,7 @@ import { cn } from '@libs/cn';
 import Icon from '@components/icon';
 import React from 'react';
 
-type CircleButtonName = 'cart' | 'back' | 'scan';
+type CircleButtonName = 'cart' | 'back' | 'scan' | 'add';
 
 type Props = {
   name: CircleButtonName;
@@ -13,7 +13,10 @@ type Props = {
   ariaLabel?: string;
 };
 
-const iconName = (n: CircleButtonName) => n;
+const iconName = (n: CircleButtonName) => {
+  if (n === 'add') return 'plus';
+  return n;
+};
 
 const base = 'cursor-pointer flex-row-center rounded-full w-[4rem] h-[4rem] shadow-scroll-fixed';
 
@@ -21,7 +24,7 @@ export default function CircleButton({ name, className = '', onClick, rotate, ic
   const r: 90 | 180 | 270 | undefined = name === 'back' ? (rotate ?? 90) : undefined;
 
   const palette =
-    name === 'scan'
+    name === 'scan' || name === 'add'
       ? 'bg-primary-900 text-gray-white'
       : 'bg-gray-white text-gray-900 outline outline-gray-200 outline-offset-[-1px]';
 

--- a/src/shared/components/tab/pill-tab.tsx
+++ b/src/shared/components/tab/pill-tab.tsx
@@ -9,13 +9,14 @@ export type PillTabProps = {
   className?: string; // 컨테이너 클래스
   scrollable?: boolean;
   label?: string;
+  disabled?: boolean;
 };
 
 const ACTIVE_BG_CLASS = 'bg-secondary-900';
 const INACTIVE_TEXT_CLASS = 'text-gray-400';
 const INACTIVE_OUTLINE_CLASS = 'outline-offset-[-1px] outline outline-gray-100';
 
-export default function PillTab({ items, value, onChange, className, label }: PillTabProps) {
+export default function PillTab({ items, value, onChange, className, label, disabled = false }: PillTabProps) {
   return (
     <div
       role='tablist'
@@ -40,7 +41,8 @@ export default function PillTab({ items, value, onChange, className, label }: Pi
               role='tab'
               aria-selected={active}
               tabIndex={active ? 0 : -1}
-              onClick={() => onChange(it.key)}
+              onClick={() => !disabled && onChange(it.key)}
+              disabled={disabled}
               className={cn(
                 'flex-row-center',
                 'cursor-pointer rounded-[22px] px-[1.6rem] py-[0.7rem]',
@@ -48,7 +50,8 @@ export default function PillTab({ items, value, onChange, className, label }: Pi
                 'transition-colors',
                 active
                   ? cn('text-gray-white', ACTIVE_BG_CLASS)
-                  : cn('bg-gray-white', INACTIVE_OUTLINE_CLASS, INACTIVE_TEXT_CLASS)
+                  : cn('bg-gray-white', INACTIVE_OUTLINE_CLASS, INACTIVE_TEXT_CLASS),
+                disabled && 'cursor-not-allowed opacity-60'
               )}
             >
               {it.label}

--- a/src/shared/components/tab/pill-tab.tsx
+++ b/src/shared/components/tab/pill-tab.tsx
@@ -8,13 +8,14 @@ export type PillTabProps = {
   onChange: (key: string) => void;
   className?: string; // 컨테이너 클래스
   scrollable?: boolean;
+  label?: string;
 };
 
 const ACTIVE_BG_CLASS = 'bg-secondary-900';
 const INACTIVE_TEXT_CLASS = 'text-gray-400';
 const INACTIVE_OUTLINE_CLASS = 'outline-offset-[-1px] outline outline-gray-100';
 
-export default function PillTab({ items, value, onChange, className }: PillTabProps) {
+export default function PillTab({ items, value, onChange, className, label }: PillTabProps) {
   return (
     <div
       role='tablist'
@@ -22,10 +23,13 @@ export default function PillTab({ items, value, onChange, className }: PillTabPr
       className={cn(
         'w-full',
         'scrollbar-hide overflow-x-auto whitespace-nowrap',
-        'h-[5.7rem] px-[2rem] py-[1rem]',
+        'min-h-[5.7rem] px-[2rem] py-[1rem]',
+        'flex-col gap-[0.8rem]',
         className
       )}
     >
+      {label && <label className='body5 mb-[0.8rem]'>{label}</label>}
+
       <div className='flex w-full items-center gap-[0.6rem]'>
         {items.map((it) => {
           const active = it.key === value;

--- a/src/shared/constants/end-point.ts
+++ b/src/shared/constants/end-point.ts
@@ -60,4 +60,5 @@ export const END_POINT = {
   // 게시판 API
   BOARD: '/board',
   BOARD_BY_ID: (boardId: string) => `/board/${boardId}`,
+  BOARD_LIKE: (boardId: string) => `/board/${boardId}/like`,
 };

--- a/src/shared/constants/end-point.ts
+++ b/src/shared/constants/end-point.ts
@@ -56,4 +56,8 @@ export const END_POINT = {
   // 회원 API
   MEMBER_ME: '/member/me',
   MEMBER_UPDATE: '/member/update',
+
+  // 게시판 API
+  BOARD: '/board',
+  BOARD_BY_ID: (boardId: string) => `/board/${boardId}`,
 };

--- a/src/shared/constants/query-keys.ts
+++ b/src/shared/constants/query-keys.ts
@@ -58,5 +58,6 @@ export const mutationKeys = {
   },
   board: {
     create: ['board', 'create'] as const,
+    delete: ['board', 'delete'] as const,
   },
 } as const;

--- a/src/shared/constants/query-keys.ts
+++ b/src/shared/constants/query-keys.ts
@@ -56,4 +56,7 @@ export const mutationKeys = {
   member: {
     update: ['member', 'update'] as const,
   },
+  board: {
+    create: ['board', 'create'] as const,
+  },
 } as const;

--- a/src/shared/constants/query-keys.ts
+++ b/src/shared/constants/query-keys.ts
@@ -28,6 +28,14 @@ export const queryKeys = {
     all: ['member'] as const,
     me: () => [...queryKeys.member.all, 'me'] as const,
   },
+
+  board: {
+    all: ['board'] as const,
+    lists: () => [...queryKeys.board.all, 'list'] as const,
+    list: (params: { title?: string; category?: string }) => [...queryKeys.board.lists(), params] as const,
+    details: () => [...queryKeys.board.all, 'detail'] as const,
+    detail: (id: string) => [...queryKeys.board.details(), id] as const,
+  },
 } as const;
 
 export const mutationKeys = {

--- a/src/shared/constants/query-keys.ts
+++ b/src/shared/constants/query-keys.ts
@@ -35,6 +35,8 @@ export const queryKeys = {
     list: (params: { title?: string; category?: string }) => [...queryKeys.board.lists(), params] as const,
     details: () => [...queryKeys.board.all, 'detail'] as const,
     detail: (id: string) => [...queryKeys.board.details(), id] as const,
+    likes: () => [...queryKeys.board.all, 'like'] as const,
+    like: (id: string) => [...queryKeys.board.likes(), id] as const,
   },
 } as const;
 
@@ -60,5 +62,6 @@ export const mutationKeys = {
     create: ['board', 'create'] as const,
     update: ['board', 'update'] as const,
     delete: ['board', 'delete'] as const,
+    like: ['board', 'like'] as const,
   },
 } as const;

--- a/src/shared/constants/query-keys.ts
+++ b/src/shared/constants/query-keys.ts
@@ -58,6 +58,7 @@ export const mutationKeys = {
   },
   board: {
     create: ['board', 'create'] as const,
+    update: ['board', 'update'] as const,
     delete: ['board', 'delete'] as const,
   },
 } as const;

--- a/src/shared/contexts/header-context.tsx
+++ b/src/shared/contexts/header-context.tsx
@@ -1,0 +1,40 @@
+import { createContext, useContext, useState, useEffect, type ReactNode } from 'react';
+import type { ActionId } from '@layouts/header';
+
+export interface HeaderOverride {
+  left?: 'back';
+  safeTop?: boolean;
+  title?: string;
+  actions?: ActionId[];
+  onAction?: (action: ActionId) => void;
+}
+
+interface HeaderContextValue {
+  override: HeaderOverride | null;
+  setOverride: (config: HeaderOverride | null) => void;
+}
+
+const HeaderContext = createContext<HeaderContextValue | undefined>(undefined);
+
+export function HeaderProvider({ children }: { children: ReactNode }) {
+  const [override, setOverride] = useState<HeaderOverride | null>(null);
+
+  return <HeaderContext.Provider value={{ override, setOverride }}>{children}</HeaderContext.Provider>;
+}
+
+export function useHeaderContext() {
+  const context = useContext(HeaderContext);
+  if (context === undefined) {
+    throw new Error('useHeaderContext must be used within HeaderProvider');
+  }
+  return context;
+}
+
+export function useHeaderOverride(config: HeaderOverride | null) {
+  const { setOverride } = useHeaderContext();
+
+  useEffect(() => {
+    setOverride(config);
+    return () => setOverride(null);
+  }, [config, setOverride]);
+}

--- a/src/shared/layouts/header-config.ts
+++ b/src/shared/layouts/header-config.ts
@@ -36,6 +36,16 @@ const boardRule: Rule = (path) =>
     ? { title: '게시판', actions: ['search', 'bell'], notificationCount: 8, safeTop: true }
     : undefined;
 
+// 커뮤니티 게시글 상세
+const boardDetailRule: Rule = (path) =>
+  matchPath({ path: ROUTES.BOARD_DETAIL() }, path) ? { left: 'back', title: '게시글 상세' } : undefined;
+
+// 커뮤니티 게시글 작성
+const boardCreateRule: Rule = (path) =>
+  matchPath({ path: ROUTES.BOARD_CREATE, end: true }, path)
+    ? { title: '커뮤니티 글 작성', actions: ['close'], safeTop: true }
+    : undefined;
+
 // 라이브러리 기본
 const libraryRootRule: Rule = (path) => {
   if (!matchPath({ path: ROUTES.LIBRARY, end: true }, path)) return undefined;
@@ -160,6 +170,8 @@ const RULES: ReadonlyArray<Rule> = [
   privacyRule,
   serviceRule,
   passwordResetRule,
+  boardCreateRule,
+  boardDetailRule,
 ];
 
 export function getHeaderForRoute(pathname: string, search: string): HeaderProps {

--- a/src/shared/layouts/layout.tsx
+++ b/src/shared/layouts/layout.tsx
@@ -8,6 +8,7 @@ import { ROUTES } from '@routes/routes-config';
 import { cn } from '@libs/cn';
 import CircleButton from '@components/button/circle-button';
 import useFloatingButtonGuard from '@hooks/use-floating-button';
+import { HeaderProvider, useHeaderContext } from '@contexts/header-context';
 
 type FloatingBtn =
   | { name: 'back'; onClick: () => void }
@@ -22,8 +23,17 @@ function isUnder(pathname: string, root: string) {
 }
 
 export default function Layout() {
+  return (
+    <HeaderProvider>
+      <LayoutContent />
+    </HeaderProvider>
+  );
+}
+
+function LayoutContent() {
   const { pathname, search } = useLocation();
   const navigate = useNavigate();
+  const { override } = useHeaderContext();
 
   const isOnboarding = useMemo(() => isUnder(pathname, ROUTES.ONBOARDING), [pathname]);
   const isChat = useMemo(() => isUnder(pathname, ROUTES.CHAT), [pathname]);
@@ -53,10 +63,21 @@ export default function Layout() {
   // 헤더는 온보딩에서만 숨김
   const showHeader = !isOnboarding;
 
-  const headerProps = useMemo(
+  // override가 있으면 override 사용, 없으면 기본 헤더 설정 사용
+  const baseHeaderProps = useMemo(
     () => (showHeader ? getHeaderForRoute(pathname, search) : null),
     [pathname, search, showHeader]
   );
+
+  const headerProps = useMemo(() => {
+    if (!showHeader) return null;
+    if (override) {
+      return {
+        ...override,
+      };
+    }
+    return baseHeaderProps;
+  }, [showHeader, override, baseHeaderProps]);
 
   const currentTab = useMemo(() => {
     const params = new URLSearchParams(search);

--- a/src/shared/layouts/layout.tsx
+++ b/src/shared/layouts/layout.tsx
@@ -45,6 +45,10 @@ function LayoutContent() {
   const isReviewCreate = useMemo(() => {
     return matchPath({ path: ROUTES.REVIEW_CREATE(':id') }, pathname) != null;
   }, [pathname]);
+  const isBoardCreate = useMemo(() => {
+    return matchPath({ path: ROUTES.BOARD_DETAIL(':id') }, pathname) != null;
+  }, [pathname]);
+
   const isNoneFooter = useMemo(
     () =>
       isUnder(pathname, ROUTES.LOGIN) ||
@@ -56,7 +60,8 @@ function LayoutContent() {
       isUnder(pathname, ROUTES.EDIT_PROFILE) ||
       isUnder(pathname, ROUTES.BOARD_CREATE) ||
       isReviewCreate ||
-      isOnboarding,
+      isOnboarding ||
+      isBoardCreate,
     [pathname]
   );
 

--- a/src/shared/layouts/layout.tsx
+++ b/src/shared/layouts/layout.tsx
@@ -13,6 +13,8 @@ type FloatingBtn =
   | { name: 'back'; onClick: () => void }
   | { name: 'scan'; onClick: () => void }
   | { name: 'cart'; onClick: () => void }
+  | { name: 'create'; onClick: () => void }
+  | { name: 'add'; onClick: () => void }
   | null;
 
 function isUnder(pathname: string, root: string) {
@@ -33,7 +35,7 @@ export default function Layout() {
   const isReviewCreate = useMemo(() => {
     return matchPath({ path: ROUTES.REVIEW_CREATE(':id') }, pathname) != null;
   }, [pathname]);
-  const isAuthOrOnboarding = useMemo(
+  const isNoneFooter = useMemo(
     () =>
       isUnder(pathname, ROUTES.LOGIN) ||
       isUnder(pathname, ROUTES.SIGNUP) ||
@@ -42,9 +44,10 @@ export default function Layout() {
       isUnder(pathname, ROUTES.BOOK_CREATE) ||
       isUnder(pathname, ROUTES.PASSWORD_RESET) ||
       isUnder(pathname, ROUTES.EDIT_PROFILE) ||
+      isUnder(pathname, ROUTES.BOARD_CREATE) ||
       isReviewCreate ||
       isOnboarding,
-    [pathname, isOnboarding, isReviewCreate]
+    [pathname]
   );
 
   // 헤더는 온보딩에서만 숨김
@@ -60,9 +63,12 @@ export default function Layout() {
     return params.get('tab') ?? 'books';
   }, [search]);
 
-  const floatingBtn: FloatingBtn = isAuthOrOnboarding
+  const floatingBtn: FloatingBtn = isNoneFooter
     ? null
     : (() => {
+        if (isUnder(pathname, ROUTES.BOARD)) {
+          return { name: 'add', onClick: () => navigate(ROUTES.BOARD_CREATE) };
+        }
         if (isUnder(pathname, ROUTES.HOME)) {
           return { name: 'back', onClick: () => window.scrollTo({ top: 0, behavior: 'smooth' }) };
         }
@@ -83,7 +89,7 @@ export default function Layout() {
     <div
       className={cn(
         'bg-gray-white min-h-dvh flex-col text-gray-900',
-        isAuthOrOnboarding ? 'h-dvh overflow-hidden' : 'h-full'
+        isNoneFooter ? 'h-dvh overflow-hidden' : 'h-full'
       )}
     >
       {showHeader && headerProps && <Header {...headerProps} />}
@@ -92,10 +98,10 @@ export default function Layout() {
         <div className='mx-auto w-full'>
           <Outlet />
         </div>
-        {!isAuthOrOnboarding && !isChat && !isCart && <Footer />}
+        {!isNoneFooter && !isChat && !isCart && <Footer />}
       </main>
 
-      {!isAuthOrOnboarding && !isChatRoom && <BottomNav />}
+      {!isNoneFooter && !isChatRoom && <BottomNav />}
 
       {floatingBtn && (
         <div
@@ -111,9 +117,11 @@ export default function Layout() {
                 <CircleButton name='back' onClick={floatingBtn.onClick} ariaLabel='맨 위로' />
               ) : floatingBtn.name === 'scan' ? (
                 <CircleButton name='scan' onClick={floatingBtn.onClick} ariaLabel='책 스캔' />
-              ) : (
+              ) : floatingBtn.name === 'cart' ? (
                 <CircleButton name='cart' onClick={floatingBtn.onClick} ariaLabel='장바구니' />
-              )}
+              ) : floatingBtn.name === 'add' ? (
+                <CircleButton name='add' onClick={floatingBtn.onClick} ariaLabel='게시글 추가' />
+              ) : null}
             </div>
           </div>
         </div>

--- a/src/shared/routes/router.tsx
+++ b/src/shared/routes/router.tsx
@@ -8,6 +8,8 @@ const HomePage = lazy(() => import('@pages/home/home-page'));
 const LibraryPage = lazy(() => import('@pages/library/library-page'));
 const SettingPage = lazy(() => import('@pages/setting/setting-page'));
 const BoardPage = lazy(() => import('@pages/board/board-page'));
+const BoardDetailPage = lazy(() => import('@pages/board/board-detail-page'));
+
 const ChatPage = lazy(() => import('@pages/chat/chat-page'));
 const ChatDetailPage = lazy(() => import('@pages/chat/chat-detail-page'));
 const NotificationPage = lazy(() => import('@pages/notification/notification-page'));
@@ -41,6 +43,7 @@ export const router = createBrowserRouter([
       { path: ROUTES.PRIVACY, element: <PrivacyPage /> },
       { path: ROUTES.TERMS_OR_SERVICE, element: <TermsOfService /> },
       { path: ROUTES.BOARD, element: <BoardPage /> },
+      { path: ROUTES.BOARD_DETAIL(':id'), element: <BoardDetailPage /> },
       { path: ROUTES.CHAT, element: <ChatPage /> },
       { path: ROUTES.CHAT_ROOM(':id'), element: <ChatDetailPage /> },
       { path: ROUTES.NOTIFICATION, element: <NotificationPage /> },

--- a/src/shared/routes/router.tsx
+++ b/src/shared/routes/router.tsx
@@ -9,7 +9,6 @@ const LibraryPage = lazy(() => import('@pages/library/library-page'));
 const SettingPage = lazy(() => import('@pages/setting/setting-page'));
 const BoardPage = lazy(() => import('@pages/board/board-page'));
 const BoardDetailPage = lazy(() => import('@pages/board/board-detail-page'));
-
 const ChatPage = lazy(() => import('@pages/chat/chat-page'));
 const ChatDetailPage = lazy(() => import('@pages/chat/chat-detail-page'));
 const NotificationPage = lazy(() => import('@pages/notification/notification-page'));
@@ -31,6 +30,7 @@ const TermsOfService = lazy(() => import('@pages/setting/terms-of-service-page')
 const ReivewCreatePage = lazy(() => import('@pages/chat/review-create-page'));
 const PasswordResetPage = lazy(() => import('@pages/setting/password-reset-page'));
 const EditProfilePage = lazy(() => import('@pages/setting/edit-profile-page'));
+const BoardCreatePage = lazy(() => import('@pages/board/board-create-page'));
 
 export const router = createBrowserRouter([
   {
@@ -44,6 +44,7 @@ export const router = createBrowserRouter([
       { path: ROUTES.TERMS_OR_SERVICE, element: <TermsOfService /> },
       { path: ROUTES.BOARD, element: <BoardPage /> },
       { path: ROUTES.BOARD_DETAIL(':id'), element: <BoardDetailPage /> },
+      { path: ROUTES.BOARD_CREATE, element: <BoardCreatePage /> },
       { path: ROUTES.CHAT, element: <ChatPage /> },
       { path: ROUTES.CHAT_ROOM(':id'), element: <ChatDetailPage /> },
       { path: ROUTES.NOTIFICATION, element: <NotificationPage /> },

--- a/src/shared/routes/routes-config.ts
+++ b/src/shared/routes/routes-config.ts
@@ -8,6 +8,7 @@ export const ROUTES = {
   BOOK_CREATE: '/book-create',
   BOARD: '/board',
   BOARD_DETAIL: (id = ':boardId') => `/board/${id}`,
+  BOARD_CREATE: '/board-create',
   ONBOARDING: '/onboarding',
   SETTING: '/mypage',
   SETTING_EDIT: '/mypage/edit',

--- a/src/shared/routes/routes-config.ts
+++ b/src/shared/routes/routes-config.ts
@@ -7,6 +7,7 @@ export const ROUTES = {
   LIBRARY_CREATE: '/library-create',
   BOOK_CREATE: '/book-create',
   BOARD: '/board',
+  BOARD_DETAIL: (id = ':boardId') => `/board/${id}`,
   ONBOARDING: '/onboarding',
   SETTING: '/mypage',
   SETTING_EDIT: '/mypage/edit',

--- a/src/shared/utils/formatDate.ts
+++ b/src/shared/utils/formatDate.ts
@@ -1,0 +1,14 @@
+export const formatDate = (dateString: string) => {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diff = now.getTime() - date.getTime();
+  const minutes = Math.floor(diff / 60000);
+  const hours = Math.floor(diff / 3600000);
+  const days = Math.floor(diff / 86400000);
+
+  if (minutes < 1) return '방금 전';
+  if (minutes < 60) return `${minutes}분 전`;
+  if (hours < 24) return `${hours}시간 전`;
+  if (days < 7) return `${days}일 전`;
+  return date.toLocaleDateString('ko-KR', { month: 'long', day: 'numeric' });
+};

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -31,6 +31,7 @@
       "@styles/*": ["./src/shared/styles/*"],
       "@components/*": ["./src/shared/components/*"],
       "@libs/*": ["./src/shared/libs/*"],
+      "@contexts/*": ["./src/shared/contexts/*"],
       "@constants/*": ["./src/shared/constants/*"],
       "@hooks/*": ["./src/shared/hooks/*"],
       "@routes/*": ["./src/shared/routes/*"],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,6 +23,7 @@ export default defineConfig(({ mode }) => {
         '@apis': path.resolve(__dirname, 'src/shared/apis'),
         '@styles': path.resolve(__dirname, 'src/shared/styles'),
         '@components': path.resolve(__dirname, 'src/shared/components'),
+        '@contexts': path.resolve(__dirname, 'src/shared/contexts'),
         '@libs': path.resolve(__dirname, 'src/shared/libs'),
         '@constants': path.resolve(__dirname, 'src/shared/constants'),
         '@hooks': path.resolve(__dirname, 'src/shared/hooks'),


### PR DESCRIPTION
## 📝작업 내용
 
  - 게시글 생성, 상세 컴포넌트 구현
  - 게시글 조회 API 연결
  - 게시글 생성 및 수정 API 연결 (생성/수정 페이지 통합)
  - 게시글 삭제 API 연결
  - 게시글 좋아요 API 연결 (추가/취소/상태 조회)
  - 레이아웃 오버라이드 context 추가

## 🐢 변경사항

**1. 게시글 생성 및 수정 기능**
도서관 생성/수정 페이지와 동일한 패턴으로 구현했습니다.
Query parameter (?id=boardId)로 생성/수정 모드 분기 합니다.
 
**2. 게시글 삭제 기능**

**3. 게시글 좋아요 기능**
페이지 로드 시 좋아요 여부 조회하고 출력합니다
좋아요 여부에 따라 API를 호출 합니다. (POST/DELETE)

**4. 커뮤니티 조회 기능**
쿼리스트링을 URL에 붙여 히스토리를 남기고 외부 접근에도 조회가 가능하도록 추가했습니다.

**5.🔥 shared 폴더 내 레이아웃 오버라이드 context 추가** 
헤더에 동적 데이터가 필요한 경우가 있는데 ( 게시글 제목 연결, 작성 게시글 조회 시 케밥 아이콘 출력 및 이를 통한 수정,삭제 시트 제어 ) 기존 레이아웃 구조에서 접근할 수 없어 전역 상태 관리를 통해 접근하도록 수정했습니다. 헤더에 접근할 컴포넌트에서 config값을 정의하고 useHeaderOverride를 통해 오버라이드 할 수 있습니다.
이에 따라 기존 레이아웃 구조에 오버라이드 식별 함수를 추가했습니다.
```js
  // override가 있으면 override 사용, 없으면 기본 헤더 설정 사용
  const baseHeaderProps = useMemo(
    () => (showHeader ? getHeaderForRoute(pathname, search) : null),
    [pathname, search, showHeader]
  );

  const headerProps = useMemo(() => {
    if (!showHeader) return null;
    if (override) {
      return {
        ...override,
      };
    }
    return baseHeaderProps;
  }, [showHeader, override, baseHeaderProps]);
```

6. contexts alias 추가
shared에 contexts 폴더 구조를 추가함에 따라 vite, ts 설정파일에 alias 추가했습니다

## 📷 스크린샷
| 조회 | 상세 | 생성/수정 |
|------|------|------------|
| <img width="300" src="https://github.com/user-attachments/assets/4c25da20-8e23-49fc-a81d-c227c10b54a6" /> | <img width="300" src="https://github.com/user-attachments/assets/cf8d7aff-38a4-480d-82d4-95ccfaa7d714" /> | <img width="300" src="https://github.com/user-attachments/assets/b6c7991c-e7df-4623-8236-aa14619c3bda" /> |


