### PR TITLE
게시판 댓글 기능 구현

### DIFF
--- a/src/pages/board/board-detail-page.tsx
+++ b/src/pages/board/board-detail-page.tsx
@@ -1,9 +1,8 @@
-import { useState, useMemo } from 'react';
+import { useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import Icon from '@components/icon';
 import CommentBottomSheet from '@components/bottom-sheet/comment-bottom-sheet';
-import type { CommentItem } from '@components/bottom-sheet/types/comment';
 import { boardQueries } from '@apis/board/board-queries';
 import { useHeaderOverride } from '@contexts/header-context';
 import type { ActionId } from '@layouts/header';
@@ -11,15 +10,18 @@ import SelectBottomSheet from '@components/bottom-sheet/select-bottom-sheet';
 import { REVIEW_MANAGE_OPTIONS } from '@components/dropdown/constants/select-options';
 import { useBoardLike } from './hooks/use-board-like';
 import { useBoardManagement } from './hooks/use-board-management';
+import { useBoardComments } from './hooks/use-board-comments';
 
 export default function BoardDetailPage() {
   const { id } = useParams<{ id: string }>();
-  const [isCommentDrawerOpen, setIsCommentDrawerOpen] = useState(false);
 
   const { data: boardDetail, isLoading } = useQuery(boardQueries.GET_BOARD_DETAIL(id!));
   const { isLiked, toggleLike } = useBoardLike(id!);
   const { isManageBottomSheetOpen, selectedManageOption, openManageSheet, closeManageSheet, handleManageOptionChange } =
     useBoardManagement(id!);
+  const { comments, isDrawerOpen, openDrawer, closeDrawer, handleToggleLike, handleSendComment } = useBoardComments(
+    id!
+  );
 
   const headerConfig = useMemo(() => {
     if (!boardDetail) return null;
@@ -38,59 +40,6 @@ export default function BoardDetailPage() {
   }, [boardDetail, openManageSheet]);
 
   useHeaderOverride(headerConfig);
-
-  const comments: CommentItem[] = [
-    {
-      id: '550e8400-e29b-41d4-a716-446655440000',
-      author: '홍길동',
-      content: '좋은 글이네요!',
-      dateText: '1시간 전',
-      createdAt: '2025-12-01T05:22:40.043Z',
-      isUpdated: true,
-      likeCount: 5,
-      liked: true,
-      isMine: true,
-      replyCount: 0,
-    },
-    {
-      id: '550e8400-e29b-41d4-a716-446655440001',
-      author: '김철수',
-      content: '저도 같은 생각입니다. 정말 유익한 정보네요.',
-      dateText: '2시간 전',
-      createdAt: '2025-12-01T06:15:20.043Z',
-      isUpdated: false,
-      likeCount: 3,
-      liked: false,
-      isMine: false,
-      replyCount: 0,
-    },
-    {
-      id: '550e8400-e29b-41d4-a716-446655440002',
-      author: '이영희',
-      content: '공감합니다. 다음에도 이런 내용 기대할게요!',
-      dateText: '3시간 전',
-      createdAt: '2025-12-01T07:30:15.043Z',
-      isUpdated: false,
-      likeCount: 8,
-      liked: true,
-      isMine: false,
-      replyCount: 0,
-    },
-  ];
-
-  const handleCommentSectionClick = () => {
-    setIsCommentDrawerOpen(true);
-  };
-
-  const handleCommentToggleLike = (kind: 'comment' | 'reply', id: string, parentId?: string) => {
-    // TODO: 댓글 좋아요 API 연동
-    console.log('Toggle comment like:', { kind, id, parentId });
-  };
-
-  const handleSendComment = async (text: string) => {
-    console.log('Send comment:', text);
-    return true;
-  };
 
   // 날짜 포맷팅 (ISO -> YYYY.MM.DD)
   const formatDate = (isoDate: string): string => {
@@ -142,29 +91,27 @@ export default function BoardDetailPage() {
 
       {/* 댓글 섹션 */}
       <section>
-        {!isCommentDrawerOpen && (
-          <div className='flex w-full gap-[1rem]'>
-            <button type='button' onClick={handleCommentSectionClick} className='cursor-pointer'>
-              <span className='flex-items-center gap-[2px]'>
-                <Icon name='comment' size={2.4} className='text-primary-900'></Icon>
-                <p className='caption1'>{boardDetail.commentCount}</p>
-              </span>
-            </button>
-            <button type='button' onClick={toggleLike} className='cursor-pointer'>
-              <span className='flex-items-center gap-[2px]'>
-                <Icon name={isLiked ? 'heart-fill' : 'heart'} size={2.4} className='text-system-error'></Icon>
-                <p className='caption1'>{boardDetail.likeCount}</p>
-              </span>
-            </button>
-          </div>
-        )}
+        <div className='flex w-full gap-[1rem]'>
+          <button type='button' onClick={openDrawer} className='cursor-pointer'>
+            <span className='flex-items-center gap-[2px]'>
+              <Icon name='comment' size={2.4} className='text-primary-900'></Icon>
+              <p className='caption1'>{boardDetail.commentCount}</p>
+            </span>
+          </button>
+          <button type='button' onClick={toggleLike} className='cursor-pointer'>
+            <span className='flex-items-center gap-[2px]'>
+              <Icon name={isLiked ? 'heart-fill' : 'heart'} size={2.4} className='text-system-error'></Icon>
+              <p className='caption1'>{boardDetail.likeCount}</p>
+            </span>
+          </button>
+        </div>
       </section>
 
       <CommentBottomSheet
-        open={isCommentDrawerOpen}
-        onClose={() => setIsCommentDrawerOpen(false)}
+        open={isDrawerOpen}
+        onClose={closeDrawer}
         comments={comments}
-        onToggleLike={handleCommentToggleLike}
+        onToggleLike={handleToggleLike}
         onSend={handleSendComment}
       />
 

--- a/src/pages/board/board-detail-page.tsx
+++ b/src/pages/board/board-detail-page.tsx
@@ -7,7 +7,7 @@ import { boardQueries } from '@apis/board/board-queries';
 import { useHeaderOverride } from '@contexts/header-context';
 import type { ActionId } from '@layouts/header';
 import SelectBottomSheet from '@components/bottom-sheet/select-bottom-sheet';
-import { REVIEW_MANAGE_OPTIONS } from '@components/dropdown/constants/select-options';
+import { COMMENT_MANAGE_OPTIONS, REVIEW_MANAGE_OPTIONS } from '@components/dropdown/constants/select-options';
 import { useBoardLike } from './hooks/use-board-like';
 import { useBoardManagement } from './hooks/use-board-management';
 import { useBoardComments } from './hooks/use-board-comments';
@@ -28,6 +28,11 @@ export default function BoardDetailPage() {
     handleSendComment,
     handleSendReply,
     handleLoadReplies,
+    handleLongPress,
+    isManageOpen: isCommentManageOpen,
+    selectedManageOption: selectedCommentManageOption,
+    closeManageSheet: closeCommentManageSheet,
+    handleManageOptionChange: handleCommentManageOptionChange,
   } = useBoardComments(id!);
 
   const headerConfig = useMemo(() => {
@@ -118,6 +123,7 @@ export default function BoardDetailPage() {
         onClose={closeDrawer}
         comments={comments}
         onToggleLike={handleToggleLike}
+        onLongPress={handleLongPress}
         onSend={handleSendComment}
         onSendReply={handleSendReply}
         onLoadReplies={handleLoadReplies}
@@ -129,6 +135,14 @@ export default function BoardDetailPage() {
         options={REVIEW_MANAGE_OPTIONS}
         value={selectedManageOption}
         onChange={handleManageOptionChange}
+      />
+
+      <SelectBottomSheet
+        open={isCommentManageOpen}
+        onClose={closeCommentManageSheet}
+        options={COMMENT_MANAGE_OPTIONS}
+        value={selectedCommentManageOption}
+        onChange={handleCommentManageOptionChange}
       />
     </main>
   );

--- a/src/pages/board/board-detail-page.tsx
+++ b/src/pages/board/board-detail-page.tsx
@@ -19,9 +19,8 @@ export default function BoardDetailPage() {
   const { isLiked, toggleLike } = useBoardLike(id!);
   const { isManageBottomSheetOpen, selectedManageOption, openManageSheet, closeManageSheet, handleManageOptionChange } =
     useBoardManagement(id!);
-  const { comments, isDrawerOpen, openDrawer, closeDrawer, handleToggleLike, handleSendComment } = useBoardComments(
-    id!
-  );
+  const { comments, isDrawerOpen, openDrawer, closeDrawer, handleToggleLike, handleSendComment, handleSendReply } =
+    useBoardComments(id!);
 
   const headerConfig = useMemo(() => {
     if (!boardDetail) return null;
@@ -113,6 +112,7 @@ export default function BoardDetailPage() {
         comments={comments}
         onToggleLike={handleToggleLike}
         onSend={handleSendComment}
+        onSendReply={handleSendReply}
       />
 
       <SelectBottomSheet

--- a/src/pages/board/board-detail-page.tsx
+++ b/src/pages/board/board-detail-page.tsx
@@ -19,8 +19,16 @@ export default function BoardDetailPage() {
   const { isLiked, toggleLike } = useBoardLike(id!);
   const { isManageBottomSheetOpen, selectedManageOption, openManageSheet, closeManageSheet, handleManageOptionChange } =
     useBoardManagement(id!);
-  const { comments, isDrawerOpen, openDrawer, closeDrawer, handleToggleLike, handleSendComment, handleSendReply } =
-    useBoardComments(id!);
+  const {
+    comments,
+    isDrawerOpen,
+    openDrawer,
+    closeDrawer,
+    handleToggleLike,
+    handleSendComment,
+    handleSendReply,
+    handleLoadReplies,
+  } = useBoardComments(id!);
 
   const headerConfig = useMemo(() => {
     if (!boardDetail) return null;
@@ -88,7 +96,6 @@ export default function BoardDetailPage() {
         </div>
       </section>
 
-      {/* 댓글 섹션 */}
       <section>
         <div className='flex w-full gap-[1rem]'>
           <button type='button' onClick={openDrawer} className='cursor-pointer'>
@@ -113,6 +120,7 @@ export default function BoardDetailPage() {
         onToggleLike={handleToggleLike}
         onSend={handleSendComment}
         onSendReply={handleSendReply}
+        onLoadReplies={handleLoadReplies}
       />
 
       <SelectBottomSheet

--- a/src/pages/board/board-page.tsx
+++ b/src/pages/board/board-page.tsx
@@ -72,7 +72,7 @@ export default function BoardPage() {
 
   const topTab = (searchParams.get('tab') as 'community' | 'reading') || 'community';
   const category = searchParams.get('category') || 'ALL';
-  const sort = (searchParams.get('sort') as SortType) || 'LATEST';
+  const sort = (searchParams.get('sort') as SortType) || '';
   const searchKeyword = searchParams.get('search') || '';
 
   const searchAnchorRef = useRef<HTMLDivElement | null>(null);
@@ -105,7 +105,6 @@ export default function BoardPage() {
     boardQueries.GET_BOARD_LIST({
       title: searchKeyword || undefined,
       category: category === 'ALL' ? undefined : category,
-      sort,
     })
   );
 

--- a/src/pages/board/hooks/use-board-comments.ts
+++ b/src/pages/board/hooks/use-board-comments.ts
@@ -2,42 +2,8 @@ import { useState, useCallback } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { commentQueries } from '@apis/board/comment-queries';
 import { commentMutations } from '@apis/board/comment-mutations';
-import type { CommentItem, ReplyItem } from '@components/bottom-sheet/types/comment';
-import type { IComment, IReply } from '@apis/board/comment-queries';
-import { formatDate } from '@/shared/utils/formatDate';
-
-function mapReplyToItem(reply: IReply): ReplyItem {
-  return {
-    id: reply.id,
-    author: reply.writerName,
-    content: reply.content,
-    dateText: formatDate(reply.createdAt),
-    createdAt: reply.createdAt,
-    isUpdated: reply.isUpdated,
-    likeCount: reply.likeCount,
-    liked: reply.likedByMe,
-    isMine: reply.isMine,
-  };
-}
-
-function mapCommentToItem(comment: IComment, loadedReplies: Record<string, IReply[]>): CommentItem {
-  const replies = loadedReplies[comment.id]?.map(mapReplyToItem);
-
-  return {
-    id: comment.id,
-    author: comment.writerName,
-    content: comment.content,
-    dateText: formatDate(comment.createdAt),
-    createdAt: comment.createdAt,
-    isUpdated: comment.isUpdated,
-    likeCount: comment.likeCount,
-    liked: comment.likedByMe,
-    isMine: comment.isMine,
-    replyCount: 0, // API에서 제공하지 않음
-    topChild: typeof comment.topChild === 'string' ? JSON.parse(comment.topChild) : comment.topChild,
-    replies,
-  };
-}
+import type { IReply } from '@apis/board/comment-queries';
+import type { ICommentWithReplies } from '@components/bottom-sheet/types/comment';
 
 export function useBoardComments(boardId: string) {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
@@ -47,8 +13,11 @@ export function useBoardComments(boardId: string) {
   const { data: commentsData = [] } = useQuery(commentQueries.GET_COMMENT_LIST(boardId));
   const createCommentMutation = useMutation(commentMutations.POST_COMMENT());
 
-  // API 응답을 CommentItem으로 변환
-  const comments: CommentItem[] = commentsData.map((comment) => mapCommentToItem(comment, loadedReplies));
+  // 서버 데이터 그대로 사용 (변환 없이)
+  const comments: ICommentWithReplies[] = commentsData.map((comment) => ({
+    ...comment,
+    replies: loadedReplies[comment.id],
+  }));
 
   const openDrawer = useCallback(() => {
     setIsDrawerOpen(true);

--- a/src/pages/board/hooks/use-board-comments.ts
+++ b/src/pages/board/hooks/use-board-comments.ts
@@ -1,12 +1,28 @@
 import { useState, useCallback } from 'react';
-import { useQuery, useMutation } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { commentQueries } from '@apis/board/comment-queries';
 import { commentMutations } from '@apis/board/comment-mutations';
-import type { CommentItem } from '@components/bottom-sheet/types/comment';
-import type { IComment } from '@apis/board/comment-queries';
+import type { CommentItem, ReplyItem } from '@components/bottom-sheet/types/comment';
+import type { IComment, IReply } from '@apis/board/comment-queries';
 import { formatDate } from '@/shared/utils/formatDate';
 
-function mapCommentToItem(comment: IComment): CommentItem {
+function mapReplyToItem(reply: IReply): ReplyItem {
+  return {
+    id: reply.id,
+    author: reply.writerName,
+    content: reply.content,
+    dateText: formatDate(reply.createdAt),
+    createdAt: reply.createdAt,
+    isUpdated: reply.isUpdated,
+    likeCount: reply.likeCount,
+    liked: reply.likedByMe,
+    isMine: reply.isMine,
+  };
+}
+
+function mapCommentToItem(comment: IComment, loadedReplies: Record<string, IReply[]>): CommentItem {
+  const replies = loadedReplies[comment.id]?.map(mapReplyToItem);
+
   return {
     id: comment.id,
     author: comment.writerName,
@@ -18,17 +34,21 @@ function mapCommentToItem(comment: IComment): CommentItem {
     liked: comment.likedByMe,
     isMine: comment.isMine,
     replyCount: 0, // API에서 제공하지 않음
+    topChild: typeof comment.topChild === 'string' ? JSON.parse(comment.topChild) : comment.topChild,
+    replies,
   };
 }
 
 export function useBoardComments(boardId: string) {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const [loadedReplies, setLoadedReplies] = useState<Record<string, IReply[]>>({});
 
+  const queryClient = useQueryClient();
   const { data: commentsData = [] } = useQuery(commentQueries.GET_COMMENT_LIST(boardId));
   const createCommentMutation = useMutation(commentMutations.POST_COMMENT());
 
   // API 응답을 CommentItem으로 변환
-  const comments: CommentItem[] = commentsData.map(mapCommentToItem);
+  const comments: CommentItem[] = commentsData.map((comment) => mapCommentToItem(comment, loadedReplies));
 
   const openDrawer = useCallback(() => {
     setIsDrawerOpen(true);
@@ -59,6 +79,21 @@ export function useBoardComments(boardId: string) {
     [boardId, createCommentMutation]
   );
 
+  const handleLoadReplies = useCallback(
+    async (parentId: string) => {
+      try {
+        const replies = await queryClient.fetchQuery(commentQueries.GET_REPLY_LIST(parentId));
+        setLoadedReplies((prev) => ({
+          ...prev,
+          [parentId]: replies,
+        }));
+      } catch (error) {
+        console.error('Failed to load replies:', error);
+      }
+    },
+    [queryClient]
+  );
+
   const handleSendReply = useCallback(
     async (parentId: string, text: string) => {
       try {
@@ -67,13 +102,15 @@ export function useBoardComments(boardId: string) {
           parentId,
           content: text,
         });
+        // 답글 작성 성공 후 대댓글 목록 다시 로드
+        await handleLoadReplies(parentId);
         return true;
       } catch (error) {
         console.error('Failed to send reply:', error);
         return false;
       }
     },
-    [boardId, createCommentMutation]
+    [boardId, createCommentMutation, handleLoadReplies]
   );
 
   return {
@@ -84,5 +121,6 @@ export function useBoardComments(boardId: string) {
     handleToggleLike,
     handleSendComment,
     handleSendReply,
+    handleLoadReplies,
   };
 }

--- a/src/pages/board/hooks/use-board-comments.ts
+++ b/src/pages/board/hooks/use-board-comments.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation } from '@tanstack/react-query';
 import { commentQueries } from '@apis/board/comment-queries';
+import { commentMutations } from '@apis/board/comment-mutations';
 import type { CommentItem } from '@components/bottom-sheet/types/comment';
 import type { IComment } from '@apis/board/comment-queries';
 import { formatDate } from '@/shared/utils/formatDate';
@@ -24,6 +25,7 @@ export function useBoardComments(boardId: string) {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
   const { data: commentsData = [] } = useQuery(commentQueries.GET_COMMENT_LIST(boardId));
+  const createCommentMutation = useMutation(commentMutations.POST_COMMENT());
 
   // API 응답을 CommentItem으로 변환
   const comments: CommentItem[] = commentsData.map(mapCommentToItem);
@@ -41,11 +43,38 @@ export function useBoardComments(boardId: string) {
     console.log('Toggle comment like:', { kind, id, parentId });
   }, []);
 
-  const handleSendComment = useCallback(async (text: string) => {
-    // TODO: 댓글 작성 API 연동
-    console.log('Send comment:', text);
-    return true;
-  }, []);
+  const handleSendComment = useCallback(
+    async (text: string) => {
+      try {
+        await createCommentMutation.mutateAsync({
+          boardId,
+          content: text,
+        });
+        return true;
+      } catch (error) {
+        console.error('Failed to send comment:', error);
+        return false;
+      }
+    },
+    [boardId, createCommentMutation]
+  );
+
+  const handleSendReply = useCallback(
+    async (parentId: string, text: string) => {
+      try {
+        await createCommentMutation.mutateAsync({
+          boardId,
+          parentId,
+          content: text,
+        });
+        return true;
+      } catch (error) {
+        console.error('Failed to send reply:', error);
+        return false;
+      }
+    },
+    [boardId, createCommentMutation]
+  );
 
   return {
     comments,
@@ -54,5 +83,6 @@ export function useBoardComments(boardId: string) {
     closeDrawer,
     handleToggleLike,
     handleSendComment,
+    handleSendReply,
   };
 }

--- a/src/pages/board/hooks/use-board-comments.ts
+++ b/src/pages/board/hooks/use-board-comments.ts
@@ -1,0 +1,58 @@
+import { useState, useCallback } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { commentQueries } from '@apis/board/comment-queries';
+import type { CommentItem } from '@components/bottom-sheet/types/comment';
+import type { IComment } from '@apis/board/comment-queries';
+import { formatDate } from '@/shared/utils/formatDate';
+
+function mapCommentToItem(comment: IComment): CommentItem {
+  return {
+    id: comment.id,
+    author: comment.writerName,
+    content: comment.content,
+    dateText: formatDate(comment.createdAt),
+    createdAt: comment.createdAt,
+    isUpdated: comment.isUpdated,
+    likeCount: comment.likeCount,
+    liked: comment.likedByMe,
+    isMine: comment.isMine,
+    replyCount: 0, // API에서 제공하지 않음
+  };
+}
+
+export function useBoardComments(boardId: string) {
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+
+  const { data: commentsData = [] } = useQuery(commentQueries.GET_COMMENT_LIST(boardId));
+
+  // API 응답을 CommentItem으로 변환
+  const comments: CommentItem[] = commentsData.map(mapCommentToItem);
+
+  const openDrawer = useCallback(() => {
+    setIsDrawerOpen(true);
+  }, []);
+
+  const closeDrawer = useCallback(() => {
+    setIsDrawerOpen(false);
+  }, []);
+
+  const handleToggleLike = useCallback((kind: 'comment' | 'reply', id: string, parentId?: string) => {
+    // TODO: 댓글 좋아요 API 연동
+    console.log('Toggle comment like:', { kind, id, parentId });
+  }, []);
+
+  const handleSendComment = useCallback(async (text: string) => {
+    // TODO: 댓글 작성 API 연동
+    console.log('Send comment:', text);
+    return true;
+  }, []);
+
+  return {
+    comments,
+    isDrawerOpen,
+    openDrawer,
+    closeDrawer,
+    handleToggleLike,
+    handleSendComment,
+  };
+}

--- a/src/pages/board/hooks/use-board-comments.ts
+++ b/src/pages/board/hooks/use-board-comments.ts
@@ -12,6 +12,8 @@ export function useBoardComments(boardId: string) {
   const queryClient = useQueryClient();
   const { data: commentsData = [] } = useQuery(commentQueries.GET_COMMENT_LIST(boardId));
   const createCommentMutation = useMutation(commentMutations.POST_COMMENT());
+  const likeCommentMutation = useMutation(commentMutations.POST_COMMENT_LIKE());
+  const unlikeCommentMutation = useMutation(commentMutations.DELETE_COMMENT_LIKE());
 
   // 서버 데이터 그대로 사용 (변환 없이)
   const comments: ICommentWithReplies[] = commentsData.map((comment) => ({
@@ -27,10 +29,42 @@ export function useBoardComments(boardId: string) {
     setIsDrawerOpen(false);
   }, []);
 
-  const handleToggleLike = useCallback((kind: 'comment' | 'reply', id: string, parentId?: string) => {
-    // TODO: 댓글 좋아요 API 연동
-    console.log('Toggle comment like:', { kind, id, parentId });
-  }, []);
+  const handleToggleLike = useCallback(
+    async (kind: 'comment' | 'reply', id: string, parentId?: string) => {
+      try {
+        let isLiked = false;
+
+        if (kind === 'comment') {
+          const comment = commentsData.find((c) => c.id === id);
+          isLiked = comment?.likedByMe ?? false;
+        } else if (kind === 'reply' && parentId) {
+          const reply = loadedReplies[parentId]?.find((r) => r.id === id);
+          isLiked = reply?.likedByMe ?? false;
+        }
+
+        if (isLiked) {
+          await unlikeCommentMutation.mutateAsync({
+            commentId: id,
+            boardId,
+            parentId,
+          });
+        } else {
+          await likeCommentMutation.mutateAsync({
+            commentId: id,
+            boardId,
+            parentId,
+          });
+        }
+
+        if (kind === 'reply' && parentId) {
+          await handleLoadReplies(parentId);
+        }
+      } catch (error) {
+        console.error('Failed to toggle like:', error);
+      }
+    },
+    [commentsData, loadedReplies, boardId, likeCommentMutation, unlikeCommentMutation]
+  );
 
   const handleSendComment = useCallback(
     async (text: string) => {

--- a/src/pages/board/hooks/use-board-comments.ts
+++ b/src/pages/board/hooks/use-board-comments.ts
@@ -4,18 +4,27 @@ import { commentQueries } from '@apis/board/comment-queries';
 import { commentMutations } from '@apis/board/comment-mutations';
 import type { IReply } from '@apis/board/comment-queries';
 import type { ICommentWithReplies } from '@components/bottom-sheet/types/comment';
+import { modal } from '@libs/modal';
+import { toast } from '@libs/toast';
 
 export function useBoardComments(boardId: string) {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [loadedReplies, setLoadedReplies] = useState<Record<string, IReply[]>>({});
+  const [isManageOpen, setIsManageOpen] = useState(false);
+  const [selectedComment, setSelectedComment] = useState<{
+    kind: 'comment' | 'reply';
+    id: string;
+    parentId?: string;
+  } | null>(null);
+  const [selectedManageOption, setSelectedManageOption] = useState<string>('');
 
   const queryClient = useQueryClient();
   const { data: commentsData = [] } = useQuery(commentQueries.GET_COMMENT_LIST(boardId));
   const createCommentMutation = useMutation(commentMutations.POST_COMMENT());
   const likeCommentMutation = useMutation(commentMutations.POST_COMMENT_LIKE());
   const unlikeCommentMutation = useMutation(commentMutations.DELETE_COMMENT_LIKE());
+  const deleteCommentMutation = useMutation(commentMutations.DELETE_COMMENT());
 
-  // 서버 데이터 그대로 사용 (변환 없이)
   const comments: ICommentWithReplies[] = commentsData.map((comment) => ({
     ...comment,
     replies: loadedReplies[comment.id],
@@ -116,6 +125,80 @@ export function useBoardComments(boardId: string) {
     [boardId, createCommentMutation, handleLoadReplies]
   );
 
+  const handleLongPress = useCallback(
+    (kind: 'comment' | 'reply', id: string, parentId?: string) => {
+      // 본인의 댓글/대댓글인지 확인
+      let isMine = false;
+      if (kind === 'comment') {
+        const comment = commentsData.find((c) => c.id === id);
+        isMine = comment?.isMine ?? false;
+      } else if (kind === 'reply' && parentId) {
+        const reply = loadedReplies[parentId]?.find((r) => r.id === id);
+        isMine = reply?.isMine ?? false;
+      }
+
+      // 본인의 것만 관리 옵션 표시
+      if (isMine) {
+        setSelectedComment({ kind, id, parentId });
+        setIsManageOpen(true);
+      }
+    },
+    [commentsData, loadedReplies]
+  );
+
+  const closeManageSheet = useCallback(() => {
+    setIsManageOpen(false);
+    setSelectedComment(null);
+    setSelectedManageOption('');
+  }, []);
+
+  const handleManageOptionChange = useCallback(
+    async (option: string) => {
+      setSelectedManageOption(option);
+
+      if (option === 'delete' && selectedComment) {
+        const isReply = selectedComment.kind === 'reply';
+        const result = await modal.confirm({
+          title: `${isReply ? '답글' : '댓글'}을 삭제하시겠습니까?`,
+          description: '삭제된 내용은 복구할 수 없습니다.',
+          confirmText: '삭제',
+          cancelText: '취소',
+          confirmVariant: 'danger',
+        });
+
+        if (result.ok) {
+          try {
+            await deleteCommentMutation.mutateAsync({
+              commentId: selectedComment.id,
+              boardId,
+              parentId: selectedComment.parentId,
+            });
+            toast.success(`${isReply ? '답글' : '댓글'}이 삭제되었습니다`);
+
+            // 대댓글 삭제 시 로컬 상태도 업데이트
+            if (isReply && selectedComment.parentId) {
+              setLoadedReplies((prev) => {
+                const parentReplies = prev[selectedComment.parentId!] || [];
+                return {
+                  ...prev,
+                  [selectedComment.parentId!]: parentReplies.filter((r) => r.id !== selectedComment.id),
+                };
+              });
+            }
+          } catch (error) {
+            console.error('Failed to delete comment:', error);
+            toast.error(`${isReply ? '답글' : '댓글'} 삭제에 실패했습니다`);
+          }
+        }
+      } else if (option === 'modify') {
+        console.log('modify:', selectedComment);
+      }
+
+      closeManageSheet();
+    },
+    [selectedComment, closeManageSheet, deleteCommentMutation, boardId]
+  );
+
   return {
     comments,
     isDrawerOpen,
@@ -125,5 +208,11 @@ export function useBoardComments(boardId: string) {
     handleSendComment,
     handleSendReply,
     handleLoadReplies,
+    handleLongPress,
+    // 관리 Bottom-sheet
+    isManageOpen,
+    selectedManageOption,
+    closeManageSheet,
+    handleManageOptionChange,
   };
 }

--- a/src/shared/apis/board/comment-mutations.ts
+++ b/src/shared/apis/board/comment-mutations.ts
@@ -1,0 +1,30 @@
+import { post } from '@apis/base/client';
+import { END_POINT } from '@constants/end-point';
+import { mutationKeys, queryKeys } from '@constants/query-keys';
+import queryClient from '@libs/query-client';
+import { mutationOptions } from '@tanstack/react-query';
+import { v4 as uuidv4 } from 'uuid';
+
+export interface ICreateCommentParams {
+  boardId: string;
+  parentId?: string;
+  content: string;
+}
+
+export const commentMutations = {
+  POST_COMMENT: () =>
+    mutationOptions<string, Error, ICreateCommentParams>({
+      mutationKey: mutationKeys.comment.create,
+      mutationFn: (data) =>
+        post<string>(END_POINT.COMMENT, data, {
+          headers: {
+            'Trace-Id': uuidv4(),
+          },
+        }),
+      onSuccess: (_, variables) => {
+        console.log(variables);
+        queryClient.invalidateQueries({ queryKey: queryKeys.comment.list(variables.boardId) });
+        queryClient.invalidateQueries({ queryKey: queryKeys.board.detail(variables.boardId) });
+      },
+    }),
+};

--- a/src/shared/apis/board/comment-mutations.ts
+++ b/src/shared/apis/board/comment-mutations.ts
@@ -17,6 +17,12 @@ export interface IToggleCommentLikeParams {
   parentId?: string;
 }
 
+export interface IDeleteCommentParams {
+  commentId: string;
+  boardId: string;
+  parentId?: string;
+}
+
 export const commentMutations = {
   POST_COMMENT: () =>
     mutationOptions<string, Error, ICreateCommentParams>({
@@ -56,6 +62,25 @@ export const commentMutations = {
       onSuccess: (_, variables) => {
         // 댓글 목록과 대댓글 목록 갱신
         queryClient.invalidateQueries({ queryKey: queryKeys.comment.list(variables.boardId) });
+        if (variables.parentId) {
+          queryClient.invalidateQueries({ queryKey: queryKeys.comment.repliesList(variables.parentId) });
+        }
+      },
+    }),
+
+  DELETE_COMMENT: () =>
+    mutationOptions<boolean, Error, IDeleteCommentParams>({
+      mutationKey: mutationKeys.comment.delete,
+      mutationFn: (data) =>
+        del<boolean>(END_POINT.COMMENT_BY_ID(data.commentId), {
+          headers: {
+            'Trace-Id': uuidv4(),
+          },
+        }),
+      onSuccess: (_, variables) => {
+        // 댓글 목록, 대댓글 목록, 게시글 상세 갱신
+        queryClient.invalidateQueries({ queryKey: queryKeys.comment.list(variables.boardId) });
+        queryClient.invalidateQueries({ queryKey: queryKeys.board.detail(variables.boardId) });
         if (variables.parentId) {
           queryClient.invalidateQueries({ queryKey: queryKeys.comment.repliesList(variables.parentId) });
         }

--- a/src/shared/apis/board/comment-mutations.ts
+++ b/src/shared/apis/board/comment-mutations.ts
@@ -25,6 +25,8 @@ export const commentMutations = {
         console.log(variables);
         queryClient.invalidateQueries({ queryKey: queryKeys.comment.list(variables.boardId) });
         queryClient.invalidateQueries({ queryKey: queryKeys.board.detail(variables.boardId) });
+        if (variables.parentId)
+          queryClient.invalidateQueries({ queryKey: queryKeys.comment.repliesList(variables.parentId) });
       },
     }),
 };

--- a/src/shared/apis/board/comment-mutations.ts
+++ b/src/shared/apis/board/comment-mutations.ts
@@ -1,4 +1,4 @@
-import { post } from '@apis/base/client';
+import { post, del } from '@apis/base/client';
 import { END_POINT } from '@constants/end-point';
 import { mutationKeys, queryKeys } from '@constants/query-keys';
 import queryClient from '@libs/query-client';
@@ -9,6 +9,12 @@ export interface ICreateCommentParams {
   boardId: string;
   parentId?: string;
   content: string;
+}
+
+export interface IToggleCommentLikeParams {
+  commentId: string;
+  boardId: string;
+  parentId?: string;
 }
 
 export const commentMutations = {
@@ -27,6 +33,32 @@ export const commentMutations = {
         queryClient.invalidateQueries({ queryKey: queryKeys.board.detail(variables.boardId) });
         if (variables.parentId)
           queryClient.invalidateQueries({ queryKey: queryKeys.comment.repliesList(variables.parentId) });
+      },
+    }),
+
+  POST_COMMENT_LIKE: () =>
+    mutationOptions<boolean, Error, IToggleCommentLikeParams>({
+      mutationKey: mutationKeys.comment.like,
+      mutationFn: (data) => post<boolean>(END_POINT.COMMENT_LIKE(data.commentId)),
+      onSuccess: (_, variables) => {
+        // 댓글 목록과 대댓글 목록 갱신
+        queryClient.invalidateQueries({ queryKey: queryKeys.comment.list(variables.boardId) });
+        if (variables.parentId) {
+          queryClient.invalidateQueries({ queryKey: queryKeys.comment.repliesList(variables.parentId) });
+        }
+      },
+    }),
+
+  DELETE_COMMENT_LIKE: () =>
+    mutationOptions<boolean, Error, IToggleCommentLikeParams>({
+      mutationKey: mutationKeys.comment.like, // POST와 동일한 키 사용
+      mutationFn: (data) => del<boolean>(END_POINT.COMMENT_LIKE(data.commentId)),
+      onSuccess: (_, variables) => {
+        // 댓글 목록과 대댓글 목록 갱신
+        queryClient.invalidateQueries({ queryKey: queryKeys.comment.list(variables.boardId) });
+        if (variables.parentId) {
+          queryClient.invalidateQueries({ queryKey: queryKeys.comment.repliesList(variables.parentId) });
+        }
       },
     }),
 };

--- a/src/shared/apis/board/comment-queries.ts
+++ b/src/shared/apis/board/comment-queries.ts
@@ -1,0 +1,27 @@
+import { get } from '@apis/base/client';
+import { END_POINT } from '@constants/end-point';
+import { queryKeys } from '@constants/query-keys';
+import { queryOptions } from '@tanstack/react-query';
+
+export interface IComment {
+  id: string;
+  content: string;
+  writerName: string;
+  createdAt: string;
+  isUpdated: boolean;
+  likeCount: number;
+  likedByMe: boolean;
+  isMine: boolean;
+  topChild: string;
+}
+
+export const commentQueries = {
+  GET_COMMENT_LIST: (boardId: string) =>
+    queryOptions<IComment[]>({
+      queryKey: queryKeys.comment.list(boardId),
+      queryFn: async () => {
+        const res = await get<IComment[]>(END_POINT.COMMENT_BY_BOARD_ID(boardId));
+        return res;
+      },
+    }),
+};

--- a/src/shared/apis/board/comment-queries.ts
+++ b/src/shared/apis/board/comment-queries.ts
@@ -15,12 +15,33 @@ export interface IComment {
   topChild: string;
 }
 
+export interface IReply {
+  id: string;
+  content: string;
+  writerName: string;
+  createdAt: string;
+  isUpdated: boolean;
+  likeCount: number;
+  likedByMe: boolean;
+  isMine: boolean;
+  topChild: string;
+}
+
 export const commentQueries = {
   GET_COMMENT_LIST: (boardId: string) =>
     queryOptions<IComment[]>({
       queryKey: queryKeys.comment.list(boardId),
       queryFn: async () => {
         const res = await get<IComment[]>(END_POINT.COMMENT_BY_BOARD_ID(boardId));
+        return res;
+      },
+    }),
+
+  GET_REPLY_LIST: (parentId: string) =>
+    queryOptions<IReply[]>({
+      queryKey: queryKeys.comment.repliesList(parentId),
+      queryFn: async () => {
+        const res = await get<IReply[]>(END_POINT.COMMENT_REPLIES(parentId));
         return res;
       },
     }),

--- a/src/shared/components/bottom-sheet/bottom-sheet.tsx
+++ b/src/shared/components/bottom-sheet/bottom-sheet.tsx
@@ -149,6 +149,7 @@ export default function BottomSheet({
 
       <div
         ref={sheetRef}
+        data-bottom-sheet
         className={cn(
           'absolute inset-x-0 bottom-0 mx-auto w-full',
           'transition-transform duration-300 ease-out',

--- a/src/shared/components/bottom-sheet/comment-bottom-sheet.tsx
+++ b/src/shared/components/bottom-sheet/comment-bottom-sheet.tsx
@@ -67,7 +67,6 @@ export default function CommentBottomSheet(props: CommentProps) {
               {comments.map((c) => {
                 const isRepliesOpen = !!openReplies[c.id];
                 const loadedCount = c.replies?.length ?? 0;
-                const hasMoreHint = c.replyCount > loadedCount;
 
                 return (
                   <li key={c.id} className='px-[1.6rem] py-[1.6rem]'>
@@ -126,17 +125,17 @@ export default function CommentBottomSheet(props: CommentProps) {
                         <span className='caption4 text-gray-800'>{c.likeCount}</span>
                       </div>
                     </div>
-                    {c.replyCount > 0 && (
+                    {c.topChild && (
                       <button
                         type='button'
                         onClick={() => toggleReplies(c.id)}
-                        className='caption4 mt-[0.6rem] cursor-pointer text-gray-700 active:opacity-80'
+                        className='caption4 mt-[0.6rem] cursor-pointer pl-[2rem] text-gray-700 active:opacity-80'
                       >
-                        {isRepliesOpen ? '답글 접기' : `— 답글 ${hasMoreHint ? c.replyCount : loadedCount}개 더 보기`}
+                        {isRepliesOpen ? '답글 접기' : `ㅡ  ${c.topChild.content}`}
                       </button>
                     )}
                     {isRepliesOpen && loadedCount > 0 && (
-                      <ul className='mt-[1.2rem] space-y-[0.8rem]'>
+                      <ul className='mt-[1.2rem] flex-col gap-[2rem]'>
                         {c.replies!.map((r) => (
                           <li key={r.id} className='flex items-start gap-[0.8rem] pl-[3.6rem]'>
                             {r.avatarUrl ? (
@@ -148,7 +147,7 @@ export default function CommentBottomSheet(props: CommentProps) {
                             ) : (
                               <div className='h-[2.2rem] w-[2.2rem] rounded-full bg-gray-100' aria-hidden />
                             )}
-                            <div className='min-w-0 flex-1'>
+                            <div className='min-w-0 flex-1 flex-col'>
                               <div className='flex items-center gap-[0.6rem]'>
                                 <p className='caption3 font-semibold text-gray-900'>{r.author}</p>
                                 <p className='caption5 text-gray-600'>{r.dateText}</p>

--- a/src/shared/components/bottom-sheet/comment-bottom-sheet.tsx
+++ b/src/shared/components/bottom-sheet/comment-bottom-sheet.tsx
@@ -148,7 +148,7 @@ export default function CommentBottomSheet(props: CommentProps) {
                                 className='p-[0.2rem] active:opacity-80'
                               >
                                 <Icon
-                                  className='text-system-error'
+                                  className='text-system-error cursor-pointer'
                                   name={r.likedByMe ? 'heart-fill' : 'heart'}
                                   size={1.6}
                                   ariaHidden

--- a/src/shared/components/bottom-sheet/comment-bottom-sheet.tsx
+++ b/src/shared/components/bottom-sheet/comment-bottom-sheet.tsx
@@ -15,7 +15,7 @@ export default function CommentBottomSheet(props: CommentProps) {
     onSendReply,
     onLoadReplies,
     indicatorStroke = true,
-    emptyText = '첫 댓글을 남겨보세요.',
+    emptyText = '첫 댓글을 남겨보세요!',
   } = props;
 
   const [text, setText] = useState('');

--- a/src/shared/components/bottom-sheet/comment-bottom-sheet.tsx
+++ b/src/shared/components/bottom-sheet/comment-bottom-sheet.tsx
@@ -44,6 +44,7 @@ export default function CommentBottomSheet(props: CommentProps) {
 
   const toggleReplies = async (parentId: string) => {
     const next = !openReplies[parentId];
+    console.log(parentId);
     setOpenReplies((m) => ({ ...m, [parentId]: next }));
     if (next) await onLoadReplies?.(parentId);
   };

--- a/src/shared/components/bottom-sheet/comment-bottom-sheet.tsx
+++ b/src/shared/components/bottom-sheet/comment-bottom-sheet.tsx
@@ -12,6 +12,7 @@ export default function CommentBottomSheet(props: CommentProps) {
     comments,
     onToggleLike,
     onReplyClick,
+    onLongPress,
     onSend,
     onSendReply,
     onLoadReplies,
@@ -24,6 +25,23 @@ export default function CommentBottomSheet(props: CommentProps) {
   const [replyTargetId, setReplyTargetId] = useState<string | null>(null);
 
   const canSend = useMemo(() => text.trim().length > 0, [text]);
+
+  // Long press 상태 관리
+  const [longPressTimer, setLongPressTimer] = useState<NodeJS.Timeout | null>(null);
+
+  const handleLongPressStart = (kind: 'comment' | 'reply', id: string, parentId?: string) => {
+    const timer = setTimeout(() => {
+      onLongPress?.(kind, id, parentId);
+    }, 500);
+    setLongPressTimer(timer);
+  };
+
+  const handleLongPressEnd = () => {
+    if (longPressTimer) {
+      clearTimeout(longPressTimer);
+      setLongPressTimer(null);
+    }
+  };
 
   const targetAuthor = useMemo(() => {
     if (replyTargetId == null) return null;
@@ -71,7 +89,15 @@ export default function CommentBottomSheet(props: CommentProps) {
 
                 return (
                   <li key={c.id} className='px-[1.6rem] py-[1.6rem]'>
-                    <div className='flex items-start gap-[1.2rem]'>
+                    <div
+                      className='flex items-start gap-[1.2rem] rounded-[8px] p-[0.8rem] transition-colors hover:bg-gray-50'
+                      onMouseDown={() => handleLongPressStart('comment', c.id)}
+                      onMouseUp={handleLongPressEnd}
+                      onMouseLeave={handleLongPressEnd}
+                      onTouchStart={() => handleLongPressStart('comment', c.id)}
+                      onTouchEnd={handleLongPressEnd}
+                      onTouchCancel={handleLongPressEnd}
+                    >
                       <div className='h-[4rem] w-[4rem] rounded-full bg-gray-100' aria-hidden />
 
                       <div className='min-w-0 flex-1'>
@@ -129,32 +155,42 @@ export default function CommentBottomSheet(props: CommentProps) {
                       </button>
                     )}
                     {isRepliesOpen && loadedCount > 0 && (
-                      <ul className='mt-[1.2rem] flex-col gap-[2rem]'>
+                      <ul className='mt-[1.2rem] flex-col gap-[0.4rem]'>
                         {c.replies!.map((r) => (
-                          <li key={r.id} className='flex items-start gap-[0.8rem] pl-[3.6rem]'>
-                            <div className='h-[2.2rem] w-[2.2rem] rounded-full bg-gray-100' aria-hidden />
-                            <div className='min-w-0 flex-1 flex-col'>
-                              <div className='flex items-center gap-[0.6rem]'>
-                                <p className='caption3 font-semibold text-gray-900'>{r.writerName}</p>
-                                <p className='caption5 text-gray-600'>{formatDate(r.createdAt)}</p>
+                          <li key={r.id} className='pl-[3.6rem]'>
+                            <div
+                              className='flex items-start gap-[0.8rem] rounded-[8px] p-[0.8rem] transition-colors hover:bg-gray-50'
+                              onMouseDown={() => handleLongPressStart('reply', r.id, c.id)}
+                              onMouseUp={handleLongPressEnd}
+                              onMouseLeave={handleLongPressEnd}
+                              onTouchStart={() => handleLongPressStart('reply', r.id, c.id)}
+                              onTouchEnd={handleLongPressEnd}
+                              onTouchCancel={handleLongPressEnd}
+                            >
+                              <div className='h-[2.2rem] w-[2.2rem] rounded-full bg-gray-100' aria-hidden />
+                              <div className='min-w-0 flex-1 flex-col'>
+                                <div className='flex items-center gap-[0.6rem]'>
+                                  <p className='caption3 font-semibold text-gray-900'>{r.writerName}</p>
+                                  <p className='caption5 text-gray-600'>{formatDate(r.createdAt)}</p>
+                                </div>
+                                <p className='caption3 mt-[0.2rem] break-words text-gray-700'>{r.content}</p>
                               </div>
-                              <p className='caption3 mt-[0.2rem] break-words text-gray-700'>{r.content}</p>
-                            </div>
-                            <div className='flex-col-center gap-[0.2rem] select-none'>
-                              <button
-                                type='button'
-                                aria-pressed={!!r.likedByMe}
-                                onClick={() => onToggleLike?.('reply', r.id, c.id)}
-                                className='p-[0.2rem] active:opacity-80'
-                              >
-                                <Icon
-                                  className='text-system-error cursor-pointer'
-                                  name={r.likedByMe ? 'heart-fill' : 'heart'}
-                                  size={1.6}
-                                  ariaHidden
-                                />
-                              </button>
-                              <span className='caption5 text-gray-800'>{r.likeCount}</span>
+                              <div className='flex-col-center gap-[0.2rem] select-none'>
+                                <button
+                                  type='button'
+                                  aria-pressed={!!r.likedByMe}
+                                  onClick={() => onToggleLike?.('reply', r.id, c.id)}
+                                  className='p-[0.2rem] active:opacity-80'
+                                >
+                                  <Icon
+                                    className='text-system-error cursor-pointer'
+                                    name={r.likedByMe ? 'heart-fill' : 'heart'}
+                                    size={1.6}
+                                    ariaHidden
+                                  />
+                                </button>
+                                <span className='caption5 text-gray-800'>{r.likeCount}</span>
+                              </div>
                             </div>
                           </li>
                         ))}

--- a/src/shared/components/bottom-sheet/comment-bottom-sheet.tsx
+++ b/src/shared/components/bottom-sheet/comment-bottom-sheet.tsx
@@ -3,6 +3,7 @@ import BottomSheet from '@components/bottom-sheet/bottom-sheet';
 import { cn } from '@libs/cn';
 import Icon from '@components/icon';
 import type { CommentProps } from '@components/bottom-sheet/types/comment';
+import { formatDate } from '@/shared/utils/formatDate';
 
 export default function CommentBottomSheet(props: CommentProps) {
   const {
@@ -26,7 +27,7 @@ export default function CommentBottomSheet(props: CommentProps) {
 
   const targetAuthor = useMemo(() => {
     if (replyTargetId == null) return null;
-    return comments.find((c) => c.id === replyTargetId)?.author ?? null;
+    return comments.find((c) => c.id === replyTargetId)?.writerName ?? null;
   }, [comments, replyTargetId]);
 
   const handleSend = async () => {
@@ -44,7 +45,6 @@ export default function CommentBottomSheet(props: CommentProps) {
 
   const toggleReplies = async (parentId: string) => {
     const next = !openReplies[parentId];
-    console.log(parentId);
     setOpenReplies((m) => ({ ...m, [parentId]: next }));
     if (next) await onLoadReplies?.(parentId);
   };
@@ -67,29 +67,27 @@ export default function CommentBottomSheet(props: CommentProps) {
               {comments.map((c) => {
                 const isRepliesOpen = !!openReplies[c.id];
                 const loadedCount = c.replies?.length ?? 0;
+                const topChild = typeof c.topChild === 'string' ? JSON.parse(c.topChild) : c.topChild;
 
                 return (
                   <li key={c.id} className='px-[1.6rem] py-[1.6rem]'>
                     <div className='flex items-start gap-[1.2rem]'>
-                      {c.avatarUrl ? (
-                        <img src={c.avatarUrl} alt='' className='h-[4rem] w-[4rem] rounded-full object-cover' />
-                      ) : (
-                        <div className='h-[4rem] w-[4rem] rounded-full bg-gray-100' aria-hidden />
-                      )}
+                      <div className='h-[4rem] w-[4rem] rounded-full bg-gray-100' aria-hidden />
 
                       <div className='min-w-0 flex-1'>
                         <div className='flex items-center gap-[0.8rem]'>
-                          <p className='body4 text-gray-900'>{c.author}</p>
-                          <p className='caption4 text-gray-600'>{c.dateText}</p>
+                          <p className='body4 text-gray-900'>{c.writerName}</p>
+                          <p className='caption4 text-gray-600'>{formatDate(c.createdAt)}</p>
                         </div>
 
                         <p className='body5 mt-[0.4rem] break-words text-gray-700'>{c.content}</p>
 
                         <div className='mt-[0.8rem] flex items-center gap-[0.8rem]'>
-                          <span className='caption4 flex items-center gap-[0.4rem] text-gray-700'>
-                            <Icon name='comment' width={1.6} height={1.6} ariaHidden />
-                            {c.replyCount}
-                          </span>
+                          {topChild && (
+                            <span className='caption4 flex items-center gap-[0.4rem] text-gray-700'>
+                              <Icon name='comment' width={1.6} height={1.6} ariaHidden />
+                            </span>
+                          )}
 
                           <button
                             type='button'
@@ -107,17 +105,13 @@ export default function CommentBottomSheet(props: CommentProps) {
                       <div className='flex-col-center gap-[0.4rem] select-none'>
                         <button
                           type='button'
-                          aria-pressed={!!c.liked}
+                          aria-pressed={!!c.likedByMe}
                           onClick={() => onToggleLike?.('comment', c.id)}
-                          disabled={c.disabled}
-                          className={cn(
-                            'cursor-pointer p-[0.2rem] active:opacity-80',
-                            c.disabled && 'cursor-not-allowed opacity-50'
-                          )}
+                          className='cursor-pointer p-[0.2rem] active:opacity-80'
                         >
                           <Icon
                             className='text-system-error'
-                            name={c.liked ? 'heart-fill' : 'heart'}
+                            name={c.likedByMe ? 'heart-fill' : 'heart'}
                             size={2}
                             ariaHidden
                           />
@@ -125,46 +119,37 @@ export default function CommentBottomSheet(props: CommentProps) {
                         <span className='caption4 text-gray-800'>{c.likeCount}</span>
                       </div>
                     </div>
-                    {c.topChild && (
+                    {topChild && (
                       <button
                         type='button'
                         onClick={() => toggleReplies(c.id)}
                         className='caption4 mt-[0.6rem] cursor-pointer pl-[2rem] text-gray-700 active:opacity-80'
                       >
-                        {isRepliesOpen ? '답글 접기' : `ㅡ  ${c.topChild.content}`}
+                        {isRepliesOpen ? '답글 접기' : `ㅡ  ${topChild.content}`}
                       </button>
                     )}
                     {isRepliesOpen && loadedCount > 0 && (
                       <ul className='mt-[1.2rem] flex-col gap-[2rem]'>
                         {c.replies!.map((r) => (
                           <li key={r.id} className='flex items-start gap-[0.8rem] pl-[3.6rem]'>
-                            {r.avatarUrl ? (
-                              <img
-                                src={r.avatarUrl}
-                                alt=''
-                                className='h-[2.2rem] w-[2.2rem] rounded-full object-cover'
-                              />
-                            ) : (
-                              <div className='h-[2.2rem] w-[2.2rem] rounded-full bg-gray-100' aria-hidden />
-                            )}
+                            <div className='h-[2.2rem] w-[2.2rem] rounded-full bg-gray-100' aria-hidden />
                             <div className='min-w-0 flex-1 flex-col'>
                               <div className='flex items-center gap-[0.6rem]'>
-                                <p className='caption3 font-semibold text-gray-900'>{r.author}</p>
-                                <p className='caption5 text-gray-600'>{r.dateText}</p>
+                                <p className='caption3 font-semibold text-gray-900'>{r.writerName}</p>
+                                <p className='caption5 text-gray-600'>{formatDate(r.createdAt)}</p>
                               </div>
                               <p className='caption3 mt-[0.2rem] break-words text-gray-700'>{r.content}</p>
                             </div>
                             <div className='flex-col-center gap-[0.2rem] select-none'>
                               <button
                                 type='button'
-                                aria-pressed={!!r.liked}
+                                aria-pressed={!!r.likedByMe}
                                 onClick={() => onToggleLike?.('reply', r.id, c.id)}
-                                disabled={r.disabled}
-                                className={cn('p-[0.2rem] active:opacity-80', r.disabled && 'opacity-50')}
+                                className='p-[0.2rem] active:opacity-80'
                               >
                                 <Icon
                                   className='text-system-error'
-                                  name={r.liked ? 'heart-fill' : 'heart'}
+                                  name={r.likedByMe ? 'heart-fill' : 'heart'}
                                   size={1.6}
                                   ariaHidden
                                 />

--- a/src/shared/components/bottom-sheet/hooks/use-outside-click.ts
+++ b/src/shared/components/bottom-sheet/hooks/use-outside-click.ts
@@ -4,7 +4,15 @@ const useOutsideClick = (ref: React.RefObject<HTMLElement | null>, handler: () =
   useEffect(() => {
     const listener = (event: MouseEvent) => {
       const el = ref.current;
-      if (!el || el.contains(event.target as Node)) return;
+      if (!el) return;
+
+      const target = event.target as Node;
+
+      const bottomSheet = document.querySelector('[role="dialog"]');
+      if (bottomSheet) return;
+
+      if (el.contains(target)) return;
+
       handler();
     };
 

--- a/src/shared/components/bottom-sheet/hooks/use-outside-click.ts
+++ b/src/shared/components/bottom-sheet/hooks/use-outside-click.ts
@@ -8,7 +8,7 @@ const useOutsideClick = (ref: React.RefObject<HTMLElement | null>, handler: () =
 
       const target = event.target as Node;
 
-      const bottomSheet = document.querySelector('[role="dialog"]');
+      const bottomSheet = document.querySelector('[data-bottom-sheet]');
       if (bottomSheet) return;
 
       if (el.contains(target)) return;

--- a/src/shared/components/bottom-sheet/types/comment.ts
+++ b/src/shared/components/bottom-sheet/types/comment.ts
@@ -28,6 +28,7 @@ export type CommentItem = {
   isUpdated?: boolean;
   isMine?: boolean;
   createdAt?: string;
+  topChild: ReplyItem;
 };
 
 export type ToggleLikeKind = 'comment' | 'reply';

--- a/src/shared/components/bottom-sheet/types/comment.ts
+++ b/src/shared/components/bottom-sheet/types/comment.ts
@@ -1,34 +1,7 @@
-export type ReplyItem = {
-  id: string;
-  avatarUrl?: string;
-  author: string;
-  dateText: string;
-  content: string;
-  likeCount: number;
-  liked?: boolean;
-  disabled?: boolean;
-  isUpdated?: boolean;
-  isMine?: boolean;
-  createdAt?: string;
-};
+import type { IComment, IReply } from '@apis/board/comment-queries';
 
-export type CommentItem = {
-  id: string;
-  avatarUrl?: string;
-  author: string;
-  dateText: string;
-  content: string;
-  likeCount: number;
-  /** 전체 답글 개수(서버 카운트) */
-  replyCount: number;
-  /** 이미 로드된 답글 목록(옵션) */
-  replies?: ReplyItem[];
-  liked?: boolean;
-  disabled?: boolean;
-  isUpdated?: boolean;
-  isMine?: boolean;
-  createdAt?: string;
-  topChild: ReplyItem;
+export type ICommentWithReplies = IComment & {
+  replies?: IReply[];
 };
 
 export type ToggleLikeKind = 'comment' | 'reply';
@@ -36,12 +9,12 @@ export type ToggleLikeKind = 'comment' | 'reply';
 export type CommentProps = {
   open: boolean;
   onClose: () => void;
-  comments: readonly CommentItem[];
+  comments: readonly ICommentWithReplies[];
   onToggleLike?: (kind: ToggleLikeKind, id: string, parentId?: string) => void;
   onReplyClick?: (parentId: string) => void;
   onSend?: (text: string) => boolean | void | Promise<boolean | void>;
   onSendReply?: (parentId: string, text: string) => boolean | void | Promise<boolean | void>;
-  onLoadReplies?: (parentId: string) => Promise<ReplyItem[] | void> | void;
+  onLoadReplies?: (parentId: string) => Promise<IReply[] | void> | void;
   indicatorStroke?: boolean;
   emptyText?: string;
   title?: string;

--- a/src/shared/components/bottom-sheet/types/comment.ts
+++ b/src/shared/components/bottom-sheet/types/comment.ts
@@ -12,6 +12,7 @@ export type CommentProps = {
   comments: readonly ICommentWithReplies[];
   onToggleLike?: (kind: ToggleLikeKind, id: string, parentId?: string) => void;
   onReplyClick?: (parentId: string) => void;
+  onLongPress?: (kind: ToggleLikeKind, id: string, parentId?: string) => void;
   onSend?: (text: string) => boolean | void | Promise<boolean | void>;
   onSendReply?: (parentId: string, text: string) => boolean | void | Promise<boolean | void>;
   onLoadReplies?: (parentId: string) => Promise<IReply[] | void> | void;

--- a/src/shared/components/dropdown/constants/select-options.ts
+++ b/src/shared/components/dropdown/constants/select-options.ts
@@ -45,3 +45,7 @@ export const REVIEW_MANAGE_OPTIONS: ReadonlyArray<{ value: ReviewManage; label: 
   { value: 'modify', label: '수정하기' },
   { value: 'delete', label: '삭제하기' },
 ];
+
+export const COMMENT_MANAGE_OPTIONS: ReadonlyArray<{ value: ReviewManage; label: string }> = [
+  { value: 'delete', label: '삭제하기' },
+];

--- a/src/shared/constants/end-point.ts
+++ b/src/shared/constants/end-point.ts
@@ -63,5 +63,6 @@ export const END_POINT = {
   BOARD_LIKE: (boardId: string) => `/board/${boardId}/like`,
 
   // 댓글 API
+  COMMENT: '/comment',
   COMMENT_BY_BOARD_ID: (boardId: string) => `/comment/${boardId}`,
 };

--- a/src/shared/constants/end-point.ts
+++ b/src/shared/constants/end-point.ts
@@ -65,4 +65,5 @@ export const END_POINT = {
   // 댓글 API
   COMMENT: '/comment',
   COMMENT_BY_BOARD_ID: (boardId: string) => `/comment/${boardId}`,
+  COMMENT_REPLIES: (parentId: string) => `/comment/${parentId}/replies`,
 };

--- a/src/shared/constants/end-point.ts
+++ b/src/shared/constants/end-point.ts
@@ -65,6 +65,7 @@ export const END_POINT = {
   // 댓글 API
   COMMENT: '/comment',
   COMMENT_BY_BOARD_ID: (boardId: string) => `/comment/${boardId}`,
+  COMMENT_BY_ID: (commentId: string) => `/comment/${commentId}`,
   COMMENT_REPLIES: (parentId: string) => `/comment/${parentId}/replies`,
   COMMENT_LIKE: (commentId: string) => `/comment/${commentId}/like`,
 };

--- a/src/shared/constants/end-point.ts
+++ b/src/shared/constants/end-point.ts
@@ -66,4 +66,5 @@ export const END_POINT = {
   COMMENT: '/comment',
   COMMENT_BY_BOARD_ID: (boardId: string) => `/comment/${boardId}`,
   COMMENT_REPLIES: (parentId: string) => `/comment/${parentId}/replies`,
+  COMMENT_LIKE: (commentId: string) => `/comment/${commentId}/like`,
 };

--- a/src/shared/constants/end-point.ts
+++ b/src/shared/constants/end-point.ts
@@ -61,4 +61,7 @@ export const END_POINT = {
   BOARD: '/board',
   BOARD_BY_ID: (boardId: string) => `/board/${boardId}`,
   BOARD_LIKE: (boardId: string) => `/board/${boardId}/like`,
+
+  // 댓글 API
+  COMMENT_BY_BOARD_ID: (boardId: string) => `/comment/${boardId}`,
 };

--- a/src/shared/constants/query-keys.ts
+++ b/src/shared/constants/query-keys.ts
@@ -70,4 +70,7 @@ export const mutationKeys = {
     delete: ['board', 'delete'] as const,
     like: ['board', 'like'] as const,
   },
+  comment: {
+    create: ['comment', 'create'] as const,
+  },
 } as const;

--- a/src/shared/constants/query-keys.ts
+++ b/src/shared/constants/query-keys.ts
@@ -74,5 +74,6 @@ export const mutationKeys = {
   },
   comment: {
     create: ['comment', 'create'] as const,
+    like: ['comment', 'like'] as const,
   },
 } as const;

--- a/src/shared/constants/query-keys.ts
+++ b/src/shared/constants/query-keys.ts
@@ -38,6 +38,12 @@ export const queryKeys = {
     likes: () => [...queryKeys.board.all, 'like'] as const,
     like: (id: string) => [...queryKeys.board.likes(), id] as const,
   },
+
+  comment: {
+    all: ['comment'] as const,
+    lists: () => [...queryKeys.comment.all, 'list'] as const,
+    list: (boardId: string) => [...queryKeys.comment.lists(), boardId] as const,
+  },
 } as const;
 
 export const mutationKeys = {

--- a/src/shared/constants/query-keys.ts
+++ b/src/shared/constants/query-keys.ts
@@ -43,6 +43,8 @@ export const queryKeys = {
     all: ['comment'] as const,
     lists: () => [...queryKeys.comment.all, 'list'] as const,
     list: (boardId: string) => [...queryKeys.comment.lists(), boardId] as const,
+    repliesLists: () => [...queryKeys.comment.all, 'replies'] as const,
+    repliesList: (parentId: string) => [...queryKeys.comment.repliesLists(), parentId] as const,
   },
 } as const;
 

--- a/src/shared/constants/query-keys.ts
+++ b/src/shared/constants/query-keys.ts
@@ -75,5 +75,6 @@ export const mutationKeys = {
   comment: {
     create: ['comment', 'create'] as const,
     like: ['comment', 'like'] as const,
+    delete: ['comment', 'delete'] as const,
   },
 } as const;


### PR DESCRIPTION
## 📝작업 내용

  -  댓글/대댓글 생성 API 연결
  -  댓글/대댓글 조회 API 연결
  -  댓글/대댓글 삭제 API 연결
  -  댓글/대댓글 좋아요 등록/취소 API 연결
  -  useOutside 이중 바텀시트 오류 수정

## 🐢 변경사항

**1. comment 관련 API 연결**

POST /api/comment
PUT /api/comment
DELETE /api/comment/{id}
POST /api/comment/{id}/like
DELETE /api/comment/{id}/like
GET /api/comment/{parentId}/replies
GET /api/comment/{boardId}

**2. 🔥 useOutside 바텀 시트 제외코드 추가**

현재 먼저 호출한 바텀 시트의 외부 영역으로 추가로 호출한 바텀 시트의 영역이 잡힙니다. 이 경우 댓글 바텀시트에서 롱프레스를 통해 수정/삭제 바텀시트를 이중으로 호출하는경우에 수정/삭제 클릭만 해도 댓글 바텀 시트가 닫히는 문제가 생겨서 **바텀시트 내부를 명시적으로 outSide영역에서 제외하는 코드를 추가했습니다.**

```jsx
  useEffect(() => {
    const listener = (event: MouseEvent) => {
      const el = ref.current;
      if (!el) return;

      const target = event.target as Node;

      const bottomSheet = document.querySelector('[data-bottom-sheet]');
      if (bottomSheet) return;

      if (el.contains(target)) return;

      handler();
    };
```

## 📷 스크린샷
| 조회 | 삭제 | 
|------|------|
| <img width="426" height="911" alt="캡처_2025_12_04_00_02_59_250" src="https://github.com/user-attachments/assets/3444f7e4-57d6-4c0b-bc79-d522f8a6a827" />| <img width="426" height="911" alt="캡처_2025_12_04_00_06_07_95" src="https://github.com/user-attachments/assets/f904bab4-1af4-4ad5-885e-ecb622d779a3" />| 

