### PR TITLE
도서관 생성, 수정, 조회 리팩토링

### DIFF
--- a/src/pages/home/home-page.tsx
+++ b/src/pages/home/home-page.tsx
@@ -21,7 +21,6 @@ import { isAuthenticated } from '@/shared/utils/auth';
 export default function HomePage() {
   const navigate = useNavigate();
 
-  // 비로그인 상태면 온보딩 페이지로 리다이렉트
   useEffect(() => {
     if (!isAuthenticated()) {
       navigate(ROUTES.ONBOARDING, { replace: true });

--- a/src/pages/library/book-create-page.tsx
+++ b/src/pages/library/book-create-page.tsx
@@ -40,7 +40,7 @@ export default function BookCreatePage() {
   const [publisher, setPublisher] = useState('');
   const [price, setPrice] = useState('');
   const [category, setCategory] = useState('');
-  const [desc, setDesc] = useState('');
+  const [description, setdescription] = useState('');
   const [deposit, setDeposit] = useState('');
   const [isbn, setIsbn] = useState('');
   const [copies, setCopies] = useState('1');
@@ -97,6 +97,7 @@ export default function BookCreatePage() {
         images,
         copies,
         deposit,
+        description,
       });
     } else {
       if (!memberData?.libraryId) {
@@ -113,6 +114,7 @@ export default function BookCreatePage() {
         category,
         isbn,
         deposit,
+        description,
         copies,
       });
     }
@@ -216,15 +218,15 @@ export default function BookCreatePage() {
         />
 
         <Input
-          id='book-desc'
+          id='book-description'
           label='상세 설명'
           placeholder='상세 설명을 작성해 주세요.'
           multiline
           maxLength={1000}
           hasLength
-          value={desc}
-          onChange={(e) => setDesc(e.currentTarget.value)}
-          length={desc.length}
+          value={description}
+          onChange={(e) => setdescription(e.currentTarget.value)}
+          length={description.length}
         />
         <Input
           id='book-copies'

--- a/src/pages/library/book-detail-page.tsx
+++ b/src/pages/library/book-detail-page.tsx
@@ -12,8 +12,6 @@ import { useKakaoMaps } from '@hooks/use-kakao-map';
 import { useMemo } from 'react';
 import type { ActionId } from '@layouts/header';
 import { useHeaderOverride } from '@contexts/header-context';
-import { memberQueries } from '@apis/member/member-queries';
-import { isAuthenticated } from '@utils/auth';
 import SelectBottomSheet from '@components/bottom-sheet/select-bottom-sheet';
 import { REVIEW_MANAGE_OPTIONS } from '@components/dropdown/constants/select-options';
 import ButtonFrame from '@components/button/button-frame';
@@ -23,7 +21,7 @@ export default function BookDetailPage() {
   const params = useParams<{ id: string }>();
   const navigate = useNavigate();
 
-  useKakaoMaps(); // Kakao Maps SDK 로드
+  useKakaoMaps();
 
   const bookId = params.id;
   const { isManageBottomSheetOpen, selectedManageOption, openManageSheet, closeManageSheet, handleManageOptionChange } =
@@ -38,25 +36,20 @@ export default function BookDetailPage() {
     enabled: !!bookId,
   });
 
-  const { data: memberData } = useQuery({
-    ...memberQueries.GET_ME(),
-    enabled: isAuthenticated(),
-  });
-
   const headerConfig = useMemo(() => {
-    if (!bookDetail || !memberData) return null;
+    if (!bookDetail) return null;
     return {
       left: 'back' as const,
       safeTop: true,
       title: bookDetail.bookDetailDto.title,
-      actions: bookDetail.libraryDto.id === memberData?.libraryId ? ['kebab' as const] : [],
+      actions: bookDetail.mine ? ['kebab' as const] : [],
       onAction: (action: ActionId) => {
         if (action === 'kebab') {
           openManageSheet();
         }
       },
     };
-  }, [bookDetail, memberData]);
+  }, [bookDetail]);
 
   useHeaderOverride(headerConfig);
 
@@ -69,7 +62,7 @@ export default function BookDetailPage() {
     );
   }
 
-  if (error || !bookDetail || !memberData) {
+  if (error || !bookDetail) {
     return null;
   }
 
@@ -85,13 +78,13 @@ export default function BookDetailPage() {
     author: bookDetailDto.author,
     publisher: bookDetailDto.publisher,
     library: libraryDto.name,
-    maxDays: 14, // TODO: API에서 제공하지 않는 필드, 기본값 설정
+    maxDays: 14,
     deposit: libraryBookDetailDto.deposit,
     status: libraryBookDetailDto.status,
-    imgUrl: libraryBookDetailDto.previewImages ? JSON.parse(libraryBookDetailDto.previewImages)[0] : undefined,
+    imgUrl: libraryBookDetailDto.previewImages,
     genre: bookDetailDto.category,
     price: bookDetailDto.originalPrice,
-    description: undefined, // TODO: API에서 제공하지 않는 필드
+    description: libraryBookDetailDto.description,
     latitude: libraryDto.latitude,
     longitude: libraryDto.longitude,
   };

--- a/src/pages/library/constants/library-messages.ts
+++ b/src/pages/library/constants/library-messages.ts
@@ -1,0 +1,14 @@
+export const LIBRARY_MESSAGES = {
+  // Book Creation
+  ISBN_REQUIRED: 'ISBN을 입력해 주세요',
+  BOOK_CREATE_SUCCESS: '도서 등록이 완료되었어요',
+  BOOK_CREATE_FAILED: '도서 등록에 실패했어요',
+  LIBRARY_BOOK_CREATE_FAILED: '도서관 도서 등록에 실패했어요',
+
+  // Book Update
+  BOOK_UPDATE_SUCCESS: '도서 수정이 완료되었어요',
+  BOOK_UPDATE_FAILED: '도서 수정에 실패했어요',
+
+  // Image Upload
+  IMAGE_UPLOAD_FAILED: '이미지 업로드에 실패했어요',
+} as const;

--- a/src/pages/library/hooks/use-create-book.ts
+++ b/src/pages/library/hooks/use-create-book.ts
@@ -10,6 +10,7 @@ import { get } from '@apis/base/client';
 import { END_POINT } from '@constants/end-point';
 import type { IBookInfo } from '@apis/book/book-queries';
 import type { ImagePreview } from '@hooks/use-image-upload';
+import { LIBRARY_MESSAGES } from '../constants/library-messages';
 
 interface CreateBookData {
   images: ImagePreview[];
@@ -20,6 +21,7 @@ interface CreateBookData {
   category: string;
   isbn: string;
   deposit: string;
+  description: string;
   copies: string;
 }
 
@@ -31,10 +33,10 @@ export function useCreateBook() {
   const { mutate: createLibraryBook } = useMutation(libraryBookMutations.POST_LIBRARY_BOOK());
 
   const submit = async (data: CreateBookData) => {
-    const { images, title, author, publisher, price, category, isbn, deposit, copies } = data;
+    const { images, title, author, publisher, price, category, isbn, deposit, copies, description } = data;
 
     if (!isbn.trim()) {
-      toast.error('ISBN을 입력해 주세요');
+      toast.error(LIBRARY_MESSAGES.ISBN_REQUIRED);
       return;
     }
 
@@ -91,6 +93,7 @@ export function useCreateBook() {
               copies: Number(copies) || 1,
               deposit: Number(deposit.trim()) || 0,
               previewImages: uploadedImageUrls,
+              description: description,
             };
 
             console.log('도서관 도서 등록 요청 데이터:', libraryBookData);
@@ -98,12 +101,12 @@ export function useCreateBook() {
             // 4. POST /library-book (도서관 도서 등록)
             createLibraryBook(libraryBookData, {
               onSuccess: () => {
-                toast.success('도서 등록이 완료되었어요');
+                toast.success(LIBRARY_MESSAGES.BOOK_CREATE_SUCCESS);
                 navigate(ROUTES.LIBRARY);
               },
               onError: (error) => {
                 console.error('도서관 도서 등록 실패:', error);
-                toast.error('도서관 도서 등록에 실패했어요');
+                toast.error(LIBRARY_MESSAGES.LIBRARY_BOOK_CREATE_FAILED);
                 setIsSubmitting(false);
               },
             });
@@ -111,7 +114,7 @@ export function useCreateBook() {
           onError: (error) => {
             console.error('도서 등록 실패:', error);
             console.error('에러 상세:', JSON.stringify(error, null, 2));
-            toast.error('도서 등록에 실패했어요');
+            toast.error(LIBRARY_MESSAGES.BOOK_CREATE_FAILED);
             setIsSubmitting(false);
           },
         });
@@ -121,6 +124,7 @@ export function useCreateBook() {
           id: bookId,
           copies: Number(copies) || 1,
           deposit: Number(deposit.trim()) || 0,
+          description: description,
           previewImages: uploadedImageUrls,
         };
 
@@ -128,19 +132,19 @@ export function useCreateBook() {
 
         createLibraryBook(libraryBookData, {
           onSuccess: () => {
-            toast.success('도서 등록이 완료되었어요');
+            toast.success(LIBRARY_MESSAGES.BOOK_CREATE_SUCCESS);
             navigate(ROUTES.LIBRARY);
           },
           onError: (error) => {
             console.error('도서관 도서 등록 실패:', error);
-            toast.error('도서관 도서 등록에 실패했어요');
+            toast.error(LIBRARY_MESSAGES.LIBRARY_BOOK_CREATE_FAILED);
             setIsSubmitting(false);
           },
         });
       }
     } catch (error) {
       console.error('이미지 업로드 실패:', error);
-      toast.error('이미지 업로드에 실패했어요');
+      toast.error(LIBRARY_MESSAGES.IMAGE_UPLOAD_FAILED);
       setIsSubmitting(false);
     }
   };

--- a/src/pages/library/hooks/use-update-book.ts
+++ b/src/pages/library/hooks/use-update-book.ts
@@ -5,6 +5,7 @@ import { libraryBookMutations } from '@apis/library/library-book-mutations';
 import { uploadImage } from '@apis/s3/s3-api';
 import { toast } from '@libs/toast';
 import type { ImagePreview } from '@hooks/use-image-upload';
+import { LIBRARY_MESSAGES } from '../constants/library-messages';
 
 interface UseUpdateBookParams {
   libraryBookId: string;
@@ -14,6 +15,7 @@ interface UpdateBookData {
   images: ImagePreview[];
   copies: string;
   deposit: string;
+  description: string;
 }
 
 export function useUpdateBook({ libraryBookId }: UseUpdateBookParams) {
@@ -23,7 +25,7 @@ export function useUpdateBook({ libraryBookId }: UseUpdateBookParams) {
   const { mutate: updateLibraryBook } = useMutation(libraryBookMutations.PATCH_LIBRARY_BOOK());
 
   const submit = async (data: UpdateBookData) => {
-    const { images, copies, deposit } = data;
+    const { images, copies, deposit, description } = data;
 
     try {
       setIsSubmitting(true);
@@ -41,23 +43,24 @@ export function useUpdateBook({ libraryBookId }: UseUpdateBookParams) {
         id: libraryBookId,
         copies: Number(copies) || 1,
         deposit: Number(deposit.trim()) || 0,
+        description: description,
         previewImages: uploadedImageUrls.filter((url) => url !== ''),
       };
 
       updateLibraryBook(updateData, {
         onSuccess: () => {
-          toast.success('도서 수정이 완료되었어요');
+          toast.success(LIBRARY_MESSAGES.BOOK_UPDATE_SUCCESS);
           navigate(`/book/${libraryBookId}`);
         },
         onError: (error) => {
           console.error('도서 수정 실패:', error);
-          toast.error('도서 수정에 실패했어요');
+          toast.error(LIBRARY_MESSAGES.BOOK_UPDATE_FAILED);
           setIsSubmitting(false);
         },
       });
     } catch (error) {
       console.error('이미지 업로드 실패:', error);
-      toast.error('이미지 업로드에 실패했어요');
+      toast.error(LIBRARY_MESSAGES.IMAGE_UPLOAD_FAILED);
       setIsSubmitting(false);
     }
   };

--- a/src/pages/library/types/library.types.ts
+++ b/src/pages/library/types/library.types.ts
@@ -14,7 +14,6 @@ export interface ILibraryBook {
   expectedReturnDate: string;
 }
 
-// 도서 상세 조회 응답 타입
 export interface ILibraryBookDetail {
   libraryDto: {
     id: string;
@@ -26,6 +25,7 @@ export interface ILibraryBookDetail {
     id: string;
     status: BookStatus;
     copies: number;
+    description?: string;
     deposit: number;
     borrowedCount: number;
     previewImages: string;
@@ -44,6 +44,7 @@ export interface ILibraryBookDetail {
     publishedDate: string;
     isbn: string;
   };
+  mine: boolean;
 }
 
 export interface IBookDetail {

--- a/src/shared/apis/base/client.ts
+++ b/src/shared/apis/base/client.ts
@@ -94,12 +94,17 @@ const createHttpClient = (baseURL: string) => {
       const originalRequest = error.config as InternalAxiosRequestConfig & { _retry?: boolean };
       const status = error.response?.status;
 
-      if (status === HTTP_STATUS.UNAUTHORIZED && !originalRequest._retry) {
+      if (
+        status === HTTP_STATUS.UNAUTHORIZED &&
+        !originalRequest._retry &&
+        originalRequest.url !== END_POINT.TOKEN_REISSUE
+      ) {
         originalRequest._retry = true;
 
         try {
           const response = await instance.post<ApiResponse<string>>(END_POINT.TOKEN_REISSUE, {});
           const newAccessToken = response.data.data;
+          console.log(response, newAccessToken);
 
           if (newAccessToken) {
             setAccessToken(newAccessToken);

--- a/src/shared/apis/library/library-book-mutations.ts
+++ b/src/shared/apis/library/library-book-mutations.ts
@@ -10,6 +10,7 @@ export interface ICreateLibraryBookParams {
   copies: number;
   deposit: number;
   previewImages: string[];
+  description: string;
 }
 
 export interface IUpdateLibraryBookParams {
@@ -17,6 +18,7 @@ export interface IUpdateLibraryBookParams {
   copies: number;
   deposit: number;
   previewImages: string[];
+  description: string;
 }
 
 export interface ICreateLibraryBookResponse {
@@ -34,7 +36,6 @@ export const libraryBookMutations = {
           },
         }),
       onSuccess: () => {
-        // Invalidate library book queries to refetch updated list
         queryClient.invalidateQueries({ queryKey: queryKeys.libraryBook.lists() });
       },
     }),


### PR DESCRIPTION
## 📝작업 내용

도서관 생성, 수정, 조회 페이지 리팩토링
리프레시토큰 재발급 오류 수정

## 🐢 변경사항

1. 도서관 생성 및 수정 페이지 토스트메세지 상수화했습니다.
2. 서버 필드 구조 변경에 맞춰 데이터 타입 변경했습니다. (description, previewImage 필드 추가)
3. AccessToken 만료시 reissue API 요청이 반복되는 오류를 수정했습니다.
